### PR TITLE
Update IBM2.scad

### DIFF
--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -64,17 +64,23 @@ UNITDIST=25.4/UNITSPERINCH;
 //element typeface
 FONT="Arial";
 //element type size
-FONTSIZE=2.4;//.05
+FONT_SIZE=2.4;//.05
+// Composer font Cap Height in points, use instead of FONT_SIZE!
+COMPOSER_CAP_HEIGHT=7;
+FONTSIZE=RENDER_MODE==0?COMPOSER_CAP_HEIGHT/2.834:FONT_SIZE;
 //secondary element typeface
 FONT2="Times New Roman";
 //secondary type size
-FONT2SIZE=2.4;//.05
+FONT2_SIZE=2.4;//.05
+// Composer font 2 Cap Height in points, use instead of FONT_SIZE!
+COMPOSER2_CAP_HEIGHT=7;
+FONT2SIZE=RENDER_MODE==0?COMPOSER2_CAP_HEIGHT/2.834:FONT2_SIZE;
 //list of chars to adopt font2 parameters
 FONT2CHARS="";
 //custom horizontal alignment characters
 CUSTOMHALIGNCHARS="";
 //custom horizontal alignment characters offset
-CUSTOMHALIGNOFFSET=1;
+CUSTOMHALIGNOFFSET=0.5;
 //type weight offset +/-
 FONT_WEIGHT_OFFSET=0;//.01
 //x weight adjustment 0+
@@ -315,7 +321,7 @@ union(){
 module Text(char, font, size, customhalign){
     offset(FONT_WEIGHT_OFFSET)
     minkowski(){
-        translate([RENDER_MODE==0?X_POS_OFFSET_COMPOSER:0+customhalign, Y_POS_OFFSET, 0])
+        translate([RENDER_MODE==0?X_POS_OFFSET_COMPOSER+customhalign:0, Y_POS_OFFSET, 0])
         mirror([1, 0, 0])
         text(char, size=size, font=font, valign="baseline", halign=H_ALIGNMENT, $fn=text_fn);
         square([z+X_WEIGHT_ADJUSTMENT, z+Y_WEIGHT_ADJUSTMENT], center=true);
@@ -370,7 +376,7 @@ module AssembleMinkowski(){
         plat_offset=PLATEN_LONGITUDE_OFFSETS[LATITUDE_LONGITUDE[hemi_int][1]];
         base_offset=BASELINE_LONGITUDE_OFFSETS[LATITUDE_LONGITUDE[hemi_int][1]];
         font=search(char, FONT2CHARS)==[]?FONT:FONT2;
-        size=search(char, FONT2CHARS)==[]?FONT2SIZE:FONTSIZE;
+        size=search(char, FONT2CHARS)==[]?FONTSIZE:FONT2SIZE;
         customhalign=search(char, CUSTOMHALIGNCHARS)==[]?0:CUSTOMHALIGNOFFSET;
         
         if (SELECTIVE_RENDER==true && search(char, SELECTIVE_RENDER_CHARS)!= [])

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -88,7 +88,7 @@ X_WEIGHT_ADJUSTMENT=.01;
 //y weight adjustment 0+
 Y_WEIGHT_ADJUSTMENT=.01;
 //x horiz alignment offset for composer
-X_POS_OFFSET_COMPOSER=1.71;//.01
+X_POS_OFFSET_COMPOSER=1.86;//.01
 //y vert alignment offset for composer
 Y_POS_OFFSET_COMPOSER=-1.5;//1.01;//.01
 //y vert alignment offset for selectric 1/2
@@ -144,7 +144,7 @@ PLATEN_OD=45;
 //radius of hollow section
 HOLLOW_R=2;
 //drive notch width
-DRIVE_NOTCH_WIDTH=1.15;
+DRIVE_NOTCH_WIDTH=1.10;
 //drive notch height
 DRIVE_NOTCH_HEIGHT=2.2;
 //drive notch theta from arrow
@@ -152,7 +152,7 @@ DRIVE_NOTCH_THETA_=131.8;
 //detent valley from center
 DETENT_VALLEY_TO_CENTER=6;
 //detent teeth clock offset
-DETENT_SKIRT_CLOCK_OFFSET=2.01;
+DETENT_SKIRT_CLOCK_OFFSET=2.51;
 
 /* [Character Polar Positioning Offsets] */
 


### PR DESCRIPTION
* Added Composer font size adjustment in point increments.
* Added decimal point to CUSTOMHALIGNOFFSET for finer control.
* Fixed CUSTOMHALIGN being enabled for S88 instead of Composer
* Fixed FONTSIZE and FONT2SIZE being reversed.