### PR TITLE
Update IBM2.scad

### DIFF
--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -26,9 +26,9 @@ RENDER_VARIANT=0;//[0:plain, 1:resin print top up, 2:type test, 3:resin print to
 //turn on minkowski?
 MINK_ON=false;
 //minkowski draft angle
-MINKOWSKI_ANGLE=85;//.5
+MINKOWSKI_ANGLE=65;//.5
 //minkowski vertical offset in degrees for R4. Halved for R3.
-MINKOWSKI_Y_OFFSET=-20;
+MINKOWSKI_Y_OFFSET=-25;
 //minkowski bottom radius size
 MINK_TEXT_R=2*tan(.5*MINKOWSKI_ANGLE);
 //cross section?


### PR DESCRIPTION
* Added Minkowski Y offset option to drop it down for R3 and R4, vastly improving overhangs for those rows.
* Added Label font offset, useful for thin fonts that would otherwise be hard to fill with paint after printing.
* Adjusted customizer comments for Composer language layouts
* Adjusted platen cutout offsets.