### PR TITLE
Update IBM2.scad

### DIFF
--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -37,7 +37,6 @@ XSECTION=false;
 XSECTION_THETA=0;
 //Degrees to rotate ball when rendering to prevent artifacts due to element aligning with pixel grid.
 RENDER_DEGREE_OFFSET=-3;
-ballspin=$preview?0:RENDER_DEGREE_OFFSET;
 
 
 
@@ -1214,7 +1213,7 @@ module ArrangeComposerLines(arrayOfStrings){
 }
 
 //Apply RENDER_DEGREE_OFFSET
-rotate([0,0,ballspin])
+rotate([0,0,$preview?0:RENDER_DEGREE_OFFSET])
 
 ///EXECUTE CODE:
 Render();

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -1217,5 +1217,4 @@ module ArrangeComposerLines(arrayOfStrings){
 rotate([0,0,ballspin])
 
 ///EXECUTE CODE:
-rotate([0,0,ballspin])
 Render();

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -35,6 +35,9 @@ MINK_TEXT_R=2*tan(.5*MINKOWSKI_ANGLE);
 XSECTION=false;
 //cross section angle?
 XSECTION_THETA=0;
+//Degrees to rotate ball when rendering to prevent artifacts due to element aligning with pixel grid.
+RENDER_DEGREE_OFFSET=-3;
+ballspin=$preview?0:RENDER_DEGREE_OFFSET;
 
 
 
@@ -1211,4 +1214,5 @@ module ArrangeComposerLines(arrayOfStrings){
 }
 
 ///EXECUTE CODE:
+rotate([0,0,ballspin])
 Render();

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -26,9 +26,9 @@ RENDER_VARIANT=0;//[0:plain, 1:resin print top up, 2:type test, 3:resin print to
 //turn on minkowski?
 MINK_ON=false;
 //minkowski draft angle
-MINKOWSKI_ANGLE=75;
+MINKOWSKI_ANGLE=65;
 //minkowski vertical offset in degrees
-MINKOWSKI_LONGITUDINAL_OFFSETS=[0, 0, 10, 20];
+MINKOWSKI_LONGITUDINAL_OFFSETS=[0, 0, 12.5, 25];
 //minkowski bottom radius size
 MINK_TEXT_R=2*tan(.5*MINKOWSKI_ANGLE);
 //cross section?

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -35,6 +35,9 @@ MINK_TEXT_R=2*tan(.5*MINKOWSKI_ANGLE);
 XSECTION=false;
 //cross section angle?
 XSECTION_THETA=0;
+//Degrees to rotate ball when rendering to prevent artifacts due to element aligning with pixel grid.
+RENDER_DEGREE_OFFSET=-3;
+ballspin=$preview?0:RENDER_DEGREE_OFFSET;
 
 
 
@@ -1209,6 +1212,9 @@ module ArrangeComposerLines(arrayOfStrings){
     //echo(lines);
     //echo(arrayOfStrings);
 }
+
+//Apply RENDER_DEGREE_OFFSET
+rotate([0,0,ballspin])
 
 ///EXECUTE CODE:
 Render();

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -246,6 +246,7 @@ TESTARRAY_LA =[
 
 //Match test array to Composer Language unless custom is checked.
 TESTARRAY=
+    (CUSTOM==true)              ? [CUSTOMLOWERCASE88,CUSTOMUPPERCASE88]:
     (CUSTOM_TEST_STRING==true)  ? [TESTSTRING_CUSTOM]:
     (COMPOSER_LANGUAGE=="US")   ? TESTARRAY_US:
     (COMPOSER_LANGUAGE=="UK")   ? TESTARRAY_UK:
@@ -1174,11 +1175,15 @@ module Labels()
 //create array of picas per test string character function
 function TestStringPicas(string)=[0, for ( i = [0:len(string)-1] ) COMPOSER_PITCH_LIST[search(string[i], COMPOSER_PITCH_LIST)[0]][1]];
 
+function CleanUpPicas(picas)=[0, for (i = [1:len(picas)-1]) (picas[i]==undef)?9:picas[i]];
+
 //composer type test gauge line with string input
 module TextGaugeComposerLine(str, unitdist)
 {
 TESTSTRINGPICAS = TestStringPicas(str);
-CUMSUMTESTSTRINGPICAS = cumulativeSum(TESTSTRINGPICAS);
+CLEANEDUPPICAS = CleanUpPicas(TESTSTRINGPICAS);
+//echo(CLEANEDUPPICAS);
+CUMSUMTESTSTRINGPICAS = cumulativeSum(CLEANEDUPPICAS);
     if(is_string(str)==true){
     color(TYPE_TEST_COLOR)
     for ( i = [0:len(str)-1] )

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -384,7 +384,7 @@ DEL_DEPTH = 0.6;
 /* [Character Polar Positioning Offsets] */
 
 //individual platen cutout adjustment angles
-PLATEN_LONGITUDE_OFFSETS=[-0.75, -0.75, -0.25, -0.6];//.05
+PLATEN_LONGITUDE_OFFSETS=[-0.85, -0.85, -0.35, -0.6];//.05
 //individual baseline adjustment angles
 BASELINE_LONGITUDE_OFFSETS=[0, 0, 0, 0];//.05
 

--- a/IBM/IBM2.scad
+++ b/IBM/IBM2.scad
@@ -246,8 +246,8 @@ TESTARRAY_LA =[
 
 //Match test array to Composer Language unless custom is checked.
 TESTARRAY=
-    (CUSTOM==true)              ? [CUSTOMLOWERCASE88,CUSTOMUPPERCASE88]:
     (CUSTOM_TEST_STRING==true)  ? [TESTSTRING_CUSTOM]:
+    (CUSTOM==true)              ? [CUSTOMLOWERCASE88,CUSTOMUPPERCASE88]:
     (COMPOSER_LANGUAGE=="US")   ? TESTARRAY_US:
     (COMPOSER_LANGUAGE=="UK")   ? TESTARRAY_UK:
     (COMPOSER_LANGUAGE=="NO")   ? TESTARRAY_NO:
@@ -612,7 +612,7 @@ LATITUDE_LONGITUDE = [for (i=[0:len(HEMISPHERE_MAP)-1]) [HEMISPHERE_MAP[i][0]%11
 
 /* [Resin Printing Offsets] */
 //amount to compensate for vat-facing boss face !CRITICAL FEATURE!
-SNOOT_DROOP_COMPENSATION=.52;
+SNOOT_DROOP_COMPENSATION=.50;
 //modeled boss to center value
 BOSS_TO_CENTER=BOSS_TO_CENTER_+SNOOT_DROOP_COMPENSATION;
 


### PR DESCRIPTION
* Adjusted alignment
* Added RENDER_DEGREE_OFFSET to rotate the element about z axis during final render so characters aren't aligned with the printer pixel grid.
* Typetest now falls back to 9 unit width if a given character is not present in the Composer pitch table.
* Enabling custom layout now shows it in type test