### PR TITLE
v4-tui: wrap long help-text/tooltip messages instead of clipping

### DIFF
--- a/v4/CLAUDE.md
+++ b/v4/CLAUDE.md
@@ -1,0 +1,32 @@
+# v4 conventions
+
+## tune.py: tooltip/help-text `Static` widgets
+
+Any `Static` whose content is user-facing help/tooltip text (the
+`.field-help`, `.picker-help`, and `.advanced-warning` CSS classes in
+`TuneApp.CSS`, and any new class serving the same purpose) must follow
+both rules below. Violating either reproduces the bug fixed in
+`SESSION_LOG.md` part 22 (text clipped, or clipped input fields below
+it).
+
+1. **`height: auto` in the CSS class, never a fixed row count.** A
+   fixed `height: N` clips any message longer than `N` lines instead of
+   wrapping it. The containing `Vertical(classes="field-row")` (or
+   equivalent) must also be `height: auto` (with `margin-bottom: 1` to
+   keep the visual spacing that a fixed height used to provide) so it
+   grows with its help text instead of clipping it.
+2. **No manual `\n` line breaks in the string.** Write the text as one
+   flowing string (ordinary adjacent-string-literal concatenation
+   across source lines is fine). Textual wraps `Static` content to the
+   widget's actual width automatically - a hand-inserted `\n` at some
+   guessed width gets wrapped *again* on top of that, roughly doubling
+   the rendered line count and pushing whatever is below it down the
+   tab. (Manual `\n` is still correct where you're building literal
+   file content, e.g. the YAML/txt headers in `save_config()` - this
+   rule is only for text a `Static` renders in the TUI.)
+
+Keep the wording itself short: 1-2 sentences, no fluff, no unnecessary
+internal/source cross-references. Longer banners (`SECTION_INTROS`,
+the Layout/Build/Type Test tab intros) should still fit in well under
+10 rendered lines - if a description needs more than that, it likely
+belongs in `README.md`/`SESSION_LOG.md` instead of a tab banner.

--- a/v4/README.md
+++ b/v4/README.md
@@ -199,8 +199,9 @@ SESSION_LOG.md parts 20-21 for the full account.
 mignon.scad's real `[Logo]` customizer section (confirmed end to end) has
 exactly ONE engraved-text feature (`Cylinder_Label`), which is what this
 app's `logo.*` config/"Logo" tab already drives. A second, independent
-`label.*` feature was added anyway (v4-only, not a v2 port) - same field
-format as Logo (font/text/size/spacing/height-offset), always placed 180
+`label.*` feature was added anyway (v4-only, not a v2 port), with its
+own "Label" tab - same field format as Logo (font/text/size/spacing/
+height-offset), always placed 180
 degrees opposite Logo's `position_offset_deg` (computed in `configure()`
 as an invariant, not independently stored - moving Logo moves Label with
 it). Defaults to empty text rather than duplicating Logo's default

--- a/v4/README.md
+++ b/v4/README.md
@@ -173,6 +173,50 @@ literally), caught via a direct render comparison, fixed by hardcoding
 the sign flip in `mignon.py`'s own `configure()` (machine-specific, not a
 `cylinder_machine.py` change).
 
+**Layout tab.** `tune.py`'s Layout tab was written when Blickensderfer/
+Postal (3 rows each) were the only machines and had "3" hardcoded as a
+literal in nine places (`BASELINE_CUTOUT_KEYS`, row-preview widget
+construction, custom-row seeding, save round-trip, etc.) - all now derive
+the row count from the config (`len(layout.baseline_row)`, etc.), which
+reduces to the same 3-row behavior for Blickensderfer/Postal
+(regression-verified) and correctly handles Mignon's 7. All 30 of
+Mignon's real named layout presets (German 4, Cyrillic, Bulgarian,
+Georgian, etc.) were ported from `v2/lib/layouts/mignon_layouts.scad`
+into `LAYOUT_PRESETS_MIGNON` (3 placeholder-empty presets in v2's own
+source were excluded; two anomalous 13-character rows in v2's Georgian/
+Greek data, unreachable by v2's own `Char_Legend` indexing, were
+truncated to 12). `layout.rows`/`LAYOUT_PRESETS_MIGNON` are stored in RAW
+KEYBOARD-LEGEND order (v2's own `Layout` array - what's printed on the
+physical keyboard/manual), not the `Char_Legend`-remapped `Physical_
+Layout` build order - `lib/mignon.py`'s `configure()` applies
+`layout.char_legend` (`[7,8,9,10,11,0,1,2,3,4,5,6]`, matching
+`v2/mignon.scad:88` exactly) to compute the actual build-time `DHIATENSOR`
+itself, so the legend can be read/edited the way a person actually reads
+it off the machine without hand-deriving the build order. See
+SESSION_LOG.md parts 20-21 for the full account.
+
+**Label - a genuine second engraved-text feature, not in v2.** v2/
+mignon.scad's real `[Logo]` customizer section (confirmed end to end) has
+exactly ONE engraved-text feature (`Cylinder_Label`), which is what this
+app's `logo.*` config/"Logo" tab already drives. A second, independent
+`label.*` feature was added anyway (v4-only, not a v2 port) - same field
+format as Logo (font/text/size/spacing/height-offset), always placed 180
+degrees opposite Logo's `position_offset_deg` (computed in `configure()`
+as an invariant, not independently stored - moving Logo moves Label with
+it). Defaults to empty text rather than duplicating Logo's default
+verbatim: at Logo's real 15deg/char spacing a normal-length label already
+spans most of the ring, so two identical strings 180 degrees apart would
+overlap rather than sit cleanly opposite each other.
+
+**Tallen (Plakatschrift) mode.** A display-type variant
+(`v2/mignon.scad:109-115,197`, off by default like this file's real
+untallened German 4 element) that adds `height_increase_mm` (3mm) to the
+element height and shifts every baseline row by
+`tallen_baseline_offset_mm` (-1.25mm) - cutout rows are NOT affected, a
+real asymmetry in v2's own source, not an oversight. Previously
+acknowledged-but-not-ported; now a real `element.tallen` toggle plus its
+two magnitude fields, all exposed on the Element tab.
+
 ### Performance
 
 The draft taper is a real Minkowski sum (`manifold3d`), not plain

--- a/v4/SESSION_LOG.md
+++ b/v4/SESSION_LOG.md
@@ -1329,6 +1329,166 @@ newly verified for Mignon (50 fields, no Gauge tab mounted, correct
 Element/Resin values, save round-trip) via headless `App.run_test()`
 against scratch config copies throughout - never the user's real files.
 
+## 20. Layout tab was hardcoded to 3 rows everywhere - fixed for Mignon's 7, imported all 30 real presets
+
+Right after the Mignon port landed, testing the Layout tab surfaced the
+obvious gap: it was written when Blickensderfer/Postal (3 physical rows
+each) were the only machines, and "3" had leaked into the code as a
+literal in nine separate places rather than being derived from the
+config. Mignon has 7 rows and, unlike Postal's single QWERTY preset, a
+real catalog of ~30 named language layouts in
+`v2/lib/layouts/mignon_layouts.scad` that were never imported.
+
+**Importing the presets.** Read all 338 lines of
+`mignon_layouts.scad` directly and transcribed its 33 raw layout
+arrays. 3 are empty placeholders in v2 itself (`CUSTOMLAYOUT`,
+`DEUTSCH_FRAKTUR_GOTISCH`, `DEUTSCH_FRAKTUR_PROF_STIEHL`) and were
+excluded, leaving 30. Each row was passed through the same
+`Char_Legend=[7,8,9,10,11,0,1,2,3,4,5,6]` remap used for Postal's
+preset import (part 14/15) - v2 authors the raw arrays in one column
+order and remaps them to physical placement order at load time, so a
+literal transcription would have been wrong. Two rows (Georgian rows
+2/4, Greek-new-ortography rows 3/4) have 13 characters in v2's source
+where every other row has 12 - confirmed this is dead data in v2
+itself (`Char_Legend` only ever indexes 0-11, so v2 never reads a
+13th character either) and truncated to `r[:12]` rather than guessing
+which character was erroneously included. Result:
+`LAYOUT_PRESETS_MIGNON`, a 30-entry dict of 7-row layouts, verified
+programmatically (all 30 x 7 x 12) before being pasted into `tune.py`
+and registered in `LAYOUT_PRESETS_BY_MACHINE["mignon"]`.
+
+**The `range(3)` sweep.** `grep -n "range(3)"` found nine hardcoded
+occurrences across `tune.py`: `BASELINE_CUTOUT_KEYS` (a module-level
+constant - had to become an instance attribute,
+`self.BASELINE_CUTOUT_KEYS`, computed in `_load_machine()` from
+`len(self.cfg["layout"]["baseline_row"])`, since row count now varies
+per machine), `_compose_baseline_cutout_fields`'s `ROW_LABELS`
+enumeration (silently dropped rows past index 3 - fixed to iterate
+`range(len(values))` and only use `ROW_LABELS[i]` as an optional
+parenthetical when in range), `_compose_layout_tab` (x2: the
+row-preview widgets and the help text's literal word "3 rows"),
+`_refresh_widgets_from_cfg` (x3), `on_select_changed`,
+`on_switch_changed`, and `_save_to_yaml`'s custom-rows collection. All
+now derive the count from actual data (`len(display_rows)`,
+`len(current_rows)`, `len(arr)`, or `n_rows` read from config)
+instead of a literal. Also restructured `_compose_layout_tab`'s
+preset-help-text branch from `if blickensderfer / elif options / else`
+to explicit per-machine `elif` branches - the old fallthrough would
+have matched Mignon into Postal's "only one physical layout" copy,
+since Mignon now has `options` truthy too, just with 30 instead of 1.
+
+**Verification**, all via headless `App.run_test()` against scratch
+config copies: Mignon - 30 presets load, dropdown correctly
+auto-detects "German 4" as the current preset from `config/mignon.yaml`'s
+rows, all 7 read-only preview widgets exist, all 14
+`baseline_row_N`/`cutout_row_N` Element-tab fields present, switching
+the dropdown to "Russian 3" + enabling "Modify glyphs" correctly seeds
+all 7 custom-row `Input` widgets from `LAYOUT_PRESETS_MIGNON["Russian
+3"]`, and a preset-switch-then-save round-trip writes the full 7 new
+rows to `layout.rows`. Blickensderfer/Postal regression - both still
+show exactly 6 baseline/cutout fields and 3 row widgets (unchanged),
+Gauge tab still mounts, Postal's single QWERTY preset still
+auto-detects correctly. Visually confirmed via an `App.run_test()`
+SVG screenshot of Mignon's Layout tab: German 4 selected, all 7 rows
+rendered with correct content, help text reads "7 rows" (not the old
+hardcoded "3 rows").
+
+## 21. Mignon Element/Logo tab audit: keyboard-legend layout order, a real second "Label" feature, Tallen mode
+
+User audit request: make sure Mignon's Element tab (and "check all other
+things") are genuinely Mignon-specific, not leftover Blickensderfer/Postal
+material, and that nothing real from v2 is missing. Cross-checked
+`ELEMENT_FIELDS_MIGNON`/`LOGO_FIELDS_MIGNON`/`QUALITY_FIELDS_MIGNON`/
+`RESIN_FIELDS_MIGNON` and `config/mignon.yaml`'s actual numeric values
+field-by-field against `v2/mignon.scad`'s real customizer sections - no
+leaked Blickensderfer/Postal fields or wrong-machine values found (every
+field list was already correctly scoped, every value matched v2 exactly).
+Found and fixed three real, distinct gaps instead:
+
+**Layout preset rows were stored in build order, not keyboard-legend
+order.** The 30 presets imported in part 20 (and `config/mignon.yaml`'s
+own `layout.rows`) were stored as v2's Char_Legend-remapped
+`Physical_Layout` (`Char_Legend=[7,8,9,10,11,0,1,2,3,4,5,6]`,
+`v2/mignon.scad:88,275`) - correct for driving the build directly, but not
+how a person reads the legend off the actual keyboard/manual (v2's own,
+separate `Layout` array). User's example: `7890-#123456` should read
+`#1234567890-`. Algebraically, `keyboard = physical[5:] + physical[:5]`
+is the *exact* inverse of the Char_Legend remap for this specific
+7-then-5 split - verified both symbolically and by round-tripping every
+row of every preset back through Char_Legend and confirming an exact
+match against the original physical-order data (zero build-output change).
+Applied that rotation to all 30 `LAYOUT_PRESETS_MIGNON` entries and to
+`config/mignon.yaml`'s `layout.rows`, added `layout.char_legend:
+[7,8,9,10,11,0,1,2,3,4,5,6]` to config, and added the actual remap step
+(`DHIATENSOR = [[row[char_legend[c]] for c in ...] for row in
+layout["rows"]]`) to `lib/mignon.py`'s `configure()` - previously
+`DHIATENSOR` was just `layout["rows"]` verbatim, silently relying on the
+stored data already being pre-remapped. Verified the rebuilt `DHIATENSOR`
+is byte-identical to the old hardcoded physical-order string for German 4
+- this is purely a display/edit-order change, the STL is unaffected.
+
+**A genuine second "Label" engraved-text feature, not in v2 at all.**
+Re-read v2/mignon.scad's real `[Logo]` customizer section (lines 218-236)
+end to end - it contains exactly ONE engraved-text feature
+(`Cylinder_Label`/`ElementLabel()`), which is what this app's existing
+`logo.*` config/tune.py "Logo" tab already drives (schema-reuse naming,
+not a second feature - confirmed Blickensderfer's real `[Logo]` section
+the same way: one `LogoText()`, no separate label concept anywhere in v2).
+User wants a second, independent one added anyway, same field format as
+Logo, permanently 180 degrees opposite it. Implemented as a genuinely new
+v4-only feature: extracted the placement math into
+`_render_engraved_text(text, size, spacing, position_offset,
+height_offset, font_path)`, renamed the existing function `ElementLabel`
+-> `ElementLogo` (unchanged behavior, still reads `logo.*`), added a new
+`ElementLabel()` reading a new `label.*` config section, with
+`Label_Position_Offset` computed as `Logo_Position_Offset + 180.0` in
+`configure()` (an invariant, not a stored/independently-editable value -
+moving Logo moves Label with it). `Additive()`/`CalibrationAdditive()`
+now union both. tune.py's `LOGO_FIELDS_MIGNON` gained 5 parallel
+`label_*`-keyed fields (font/text/size/spacing/height-offset, no position
+field since it's derived) in the same "Logo" tab, `label_font_path` added
+to `FONT_PATH_FIELD_KEYS` for its own Browse button. Default `label.text`
+is empty, NOT a copy of `logo.text` - checked the math first: at Logo's
+real 15deg/char spacing, "Leonard Chau 2026" (18 chars) already spans
+~255 degrees, so a second copy 180 degrees away would heavily overlap the
+first instead of sitting cleanly opposite it (255+255 > 360). Verified via
+direct `FullElement()` builds + `f3d` renders: default (empty label)
+builds clean; a short test string ("TEST") renders legibly at the bottom
+of the chamfer ring while "Leonard Chau 2026" occupies the top - visually
+confirmed 180 degrees apart, no overlap.
+
+**Tallen (Plakatschrift) mode - acknowledged missing in the original port
+comment, now implemented.** `v2/mignon.scad:109-115,197`: a display-type
+variant that adds `Height_Increase` (3mm) to `Element_Height` and shifts
+every `Baseline` row by `Tallen_Baseline_Offset` (-1.25mm) when
+`Tallen=true` - `Cutout` has no Tallen variant in v2 at all, a real
+asymmetry (Baseline shifts, Cutout doesn't), not an oversight to fix.
+Added `element.tallen`/`height_increase_mm`/`tallen_baseline_offset_mm`
+to config (off by default, matching v2 and this file's real untallened
+German 4 element), wired into `configure()`
+(`Element_Height`/`BASELINE_ROW` both conditional on `Tallen`, `CUTOUT_ROW`
+untouched), and exposed as three new `ELEMENT_FIELDS_MIGNON` entries.
+Verified: `Tallen=false` reproduces the exact prior `Element_Height`
+(40.5) and `BASELINE_ROW` values; `Tallen=true` gives 43.5 and every
+baseline shifted by exactly -1.25 with `CUTOUT_ROW` unchanged; full builds
+succeed watertight in both states.
+
+Deliberately NOT touched, flagged as pre-existing/cross-machine gaps
+rather than Mignon-specific bugs (would be real scope creep to fix here):
+v2's "unified" glyph-quality system (`Weight_Adj_Mode`/`Scale_Multiplier`/
+`Y_Scale`/`Text_Align_Method` and friends) has no v4 implementation for
+ANY machine, not just Mignon (`grep` confirmed zero references anywhere
+in `lib/*.py`). Same for `Character_Modifieds`/`Typeface_2` (per-character
+baseline shift + secondary-font-by-character) - present in ALL THREE v2
+machine files, not ported for any of them. Both belong in a dedicated
+follow-up, not folded into a "make Mignon's existing fields correct" pass.
+
+Regression-verified Blickensderfer/Postal: field counts unchanged
+(78/73), no duplicate `self.inputs` keys introduced by the new
+`label_*`/`tallen`/etc. keys (checked across the whole file, not just
+Mignon's own section, since `self.inputs` is a single flat dict), no
+Mignon-only keys leaked into their field sets.
+
 ## Resuming later
 
 1. **Bennett, then Helios** - the next two machines per the original
@@ -1345,3 +1505,7 @@ against scratch config copies throughout - never the user's real files.
 3. Everything in part 14's original "Resuming later" list (separation_mm,
    inter-character collisions, performance, alignment offsets,
    platen_fn/body_fn) is still open.
+4. v2's "unified" glyph-quality system (Weight_Adj_Mode/Scale_Multiplier/
+   Y_Scale/Text_Align_Method/Text_Align_Modified*) and the Character_
+   Modifieds/Typeface_2 per-character override systems have no v4
+   implementation for ANY machine (not Mignon-specific) - see part 21.

--- a/v4/SESSION_LOG.md
+++ b/v4/SESSION_LOG.md
@@ -1489,6 +1489,43 @@ Regression-verified Blickensderfer/Postal: field counts unchanged
 Mignon's own section, since `self.inputs` is a single flat dict), no
 Mignon-only keys leaked into their field sets.
 
+## 22. tune.py help-text/tooltip `Static`s were clipped, then found to double-wrap once un-clipped
+
+User report: tooltip/help messages in the TUI get cut off when longer
+than their box. Traced to `.field-help`, `.picker-help`, and
+`.advanced-warning` all being pinned to a fixed `height` (1 or 2 rows)
+in `TuneApp.CSS` - any message longer than that was clipped instead of
+wrapping. Worst offenders were the Gauge/Calibration `SECTION_INTROS`
+banners: authored as 7-9 line strings but rendered squashed to a single
+visible line. Fixed by switching `.field-help`/`.picker-help`/
+`.advanced-warning` to `height: auto` (and `.field-row` to `height:
+auto` + `margin-bottom: 1`, since it previously relied on a fixed
+`height: 2` for both the Horizontal row and its optional help line).
+
+That surfaced a second, distinct bug: those same banners (and the
+Layout tab's per-machine notes, the Build tab's target explainer, the
+Type Test intro) were hand-wrapped with embedded `\n` at some assumed
+width. With the box now auto-sizing, Textual wrapped each
+already-broken line a *second* time - confirmed via a headless
+`App.run_test()` region check, Gauge's 7-line intro rendered at
+`height=14`. On a normal-height terminal this pushed the real
+Offset start/Offset int inputs (Gauge) and test_char/start/interval
+inputs (Calibration) far enough down the tab to require scrolling past
+the fold - reported by the user as the text "covering" the inputs and
+making them impossible to edit. Fixed by removing every manual `\n`
+line break from TUI-displayed help text (single flowing string, wraps
+exactly once) and rewriting the wording shorter throughout - dropped
+internal v2-source cross-references and redundant clauses. Re-verified
+headlessly: Gauge's intro dropped from 14 rendered lines to 6, with
+both its inputs landing at row 12/15 even in a 24-row terminal.
+Short one-line field-level hints (e.g. "TrueType font for the struck
+characters.") were already concise and left untouched.
+
+New standing rule for any tooltip/help-text `Static` added to tune.py
+from here on - see `CLAUDE.md`: `height: auto`, never a fixed row
+count; no manual `\n` line breaks (let Textual wrap once); keep the
+wording to 1-2 short sentences.
+
 ## Resuming later
 
 1. **Bennett, then Helios** - the next two machines per the original

--- a/v4/config/mignon.yaml
+++ b/v4/config/mignon.yaml
@@ -43,15 +43,45 @@ logo:
   # surface, a genuinely different placement geometry).
   height_offset_mm: 0.5
 
+# v4-only second engraved-text feature (NOT a v2 concept - v2/mignon.scad
+# has exactly one, Cylinder_Label, ported above as logo.*) - same
+# font/size/spacing/height-offset format as logo above, always placed 180
+# degrees opposite logo's position_offset_deg (derived in lib/mignon.py's
+# configure(), not stored here - editing logo.position_offset_deg keeps
+# the label locked opposite it). text defaults to empty (renders nothing)
+# rather than duplicating logo.text verbatim - at logo's real 15deg/char
+# spacing, "Leonard Chau 2026" (18 chars) already spans ~255 degrees, so a
+# second copy of it 180 degrees away would heavily overlap the first
+# rather than sitting cleanly opposite it. Fill in your own shorter text.
+# Keys prefixed label_* (not font_path/text/... like logo above) - tune.py's
+# patch_yaml_value matches by bare key text across the WHOLE config file,
+# not by section, so identical key names under logo:/label: would collide
+# (the same literal "font_path:"/"text:"/etc. appearing twice) and patch
+# the wrong one - every YAML key patch_yaml_value can touch must be
+# globally unique in the file (see GAUGE_FIELDS' matching comment in tune.py).
+label:
+  label_font_path: "/home/lchau/fonts/Library/Typewriter & Monospace/Iosevka Etoile.ttf"
+  label_text: ""
+  label_text_size_mm: 1.2495
+  label_text_spacing: 15.0
+  label_height_offset_mm: 0.5
+
 element:
   platen_diameter: 26.5
   element_diameter: 18.64
   min_final_character_diameter: 19.4
-  # Cylinder_Height_=40.5 (Tallen=false, so Element_Height = this
-  # directly - Tallen/Height_Increase/Tallen_Baseline_Offset, a
-  # Plakatschrift-specific variant, not ported - element_height below
-  # already reflects the untallened value real machines use).
+  # Cylinder_Height_=40.5 - the BASE/untallened height; actual built
+  # Element_Height adds height_increase_mm on top of this when tallen is on.
   element_height: 40.5
+  # Tallen (Plakatschrift, a display-type variant) - v2/mignon.scad:109-
+  # 115,197. Off by default (matches v2's Tallen=false and this file's
+  # real Layout_Selection=5 German 4 default, an untallened element).
+  # When on: Element_Height = element_height + height_increase_mm, and
+  # every baseline row shifts by tallen_baseline_offset_mm (cutout rows
+  # are NOT affected - v2 has no Cutout_Tallen variant).
+  tallen: false
+  height_increase_mm: 3.0
+  tallen_baseline_offset_mm: -1.25
   cylinder_top_height_offset: 3.0
   cylinder_top_chamfer: 2.0
   cylinder_top_diameter: 10.5
@@ -77,22 +107,30 @@ quality:
 # face - v2/mignon.scad:281 Baseline_Z_Offset=0, unlike Blickensderfer/
 # Postal's negative-from-clip-end convention), latitude spacing, and the
 # physical layout (v2's German 4 / Layouts[5], the real default -
-# Layout_Selection=5 - remapped through Char_Legend=[7,8,9,10,11,0,1,2,3,
-# 4,5,6] the same way Postal's Physical_Layout is pre-baked, since Mignon
-# also has no separate placement_map override - identity below).
+# Layout_Selection=5).
+#
+# rows: stored in RAW KEYBOARD-LEGEND order (v2's `Layout` array, matching
+# what's printed on the physical keyboard/manual), NOT the Char_Legend-
+# remapped `Physical_Layout` order used for actual glyph placement -
+# mignon.py's configure() applies char_legend below to compute the real
+# build-time DHIATENSOR, mirroring v2/mignon.scad:275's
+# Physical_Layout=[for (row) [for (col) Layout[row][Char_Legend[col]]]]
+# exactly. Mignon also has no separate placement_map override beyond
+# Char_Legend - identity below.
 layout:
   baseline_row: [2.25, 7.55, 12.75, 17.8, 22.8, 28.0, 32.8]
   cutout_row: [2.7, 8.25, 13.6, 18.7, 23.7, 28.7, 33.6]
   latitude_columns: 12
   placement_map: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+  char_legend: [7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 6]
   rows:
-    - "'äöü_&():\"!?"
-    - "fugq;§PFUGQp"
-    - "inabjJVINABv"
-    - "detm,/LDETMl"
-    - "osrz=%KOSRZk"
-    - "chwx+¾YCHWXy"
-    - "789.-½¼23456"
+    - "&():\"!?'äöü_"
+    - "§PFUGQpfugq;"
+    - "JVINABvinabj"
+    - "/LDETMldetm,"
+    - "%KOSRZkosrz="
+    - "¾YCHWXychwx+"
+    - "½¼23456789.-"
   modify_glyphs: false
 
 alignment:

--- a/v4/lib/mignon.py
+++ b/v4/lib/mignon.py
@@ -77,12 +77,30 @@ def configure(config_path):
     g["Logo_Text_Size"] = logo["text_size_mm"]
     g["Logo_Text_Spacing"] = logo["text_spacing"]
     g["Logo_Position_Offset"] = logo["position_offset_deg"]
-    # Cylinder_Label_Height_Offset - the label's local radial nudge off
-    # the chamfer surface (ElementLabel's own transform, unrelated to
-    # Blickensderfer/Postal's Logo_Radial_Offset - Mignon's label sits on
-    # an angled chamfer surface, not the flat top face, so its geometry
-    # needs a different placement chain entirely, see ElementLabel()).
+    # Cylinder_Label_Height_Offset - the local radial nudge off the chamfer
+    # surface (ElementLogo's own transform, unrelated to Blickensderfer/
+    # Postal's Logo_Radial_Offset - Mignon's logo/label sit on an angled
+    # chamfer surface, not the flat top face, so their geometry needs a
+    # different placement chain entirely, see _render_engraved_text()).
     g["Logo_Height_Offset"] = logo["height_offset_mm"]
+
+    # Label: NOT a v2 concept (v2/mignon.scad has exactly one engraved-text
+    # feature, Cylinder_Label, which is what Logo_* above already is - see
+    # ElementLogo()'s docstring) - a v4-only second engraved-text feature,
+    # same rendering chain as Logo, always placed 180 degrees around from
+    # it (Label_Position_Offset is DERIVED, not stored - "180 degrees
+    # opposite from Logo text" is an invariant, not just an initial value).
+    # label_* keys (not font_path/text/... like logo above) - config's own
+    # comment explains why: tune.py's patch_yaml_value matches by bare key
+    # text across the whole file, so identical key names under logo:/
+    # label: would collide.
+    label = cfg["label"]
+    g["LABEL_FONT_PATH"] = label["label_font_path"]
+    g["Label_Text"] = label["label_text"]
+    g["Label_Text_Size"] = label["label_text_size_mm"]
+    g["Label_Text_Spacing"] = label["label_text_spacing"]
+    g["Label_Height_Offset"] = label["label_height_offset_mm"]
+    g["Label_Position_Offset"] = logo["position_offset_deg"] + 180.0
 
     e = cfg["element"]
     g["z"] = 0.001
@@ -90,7 +108,18 @@ def configure(config_path):
     g["Platen_Diameter"] = e["platen_diameter"]
     g["Min_Final_Character_Diameter"] = e["min_final_character_diameter"]
     g["Char_Protrusion"] = (e["min_final_character_diameter"] - e["element_diameter"]) / 2.0
-    g["Element_Height"] = e["element_height"]
+    # v2/mignon.scad:109-115,197 - Tallen (Plakatschrift, a display-type
+    # variant): Element_Height=Cylinder_Height_+Height_Increase when on
+    # (element_height below is Cylinder_Height_, the base/untallened
+    # value), and every Baseline row shifts by Tallen_Baseline_Offset -
+    # Cutout is NOT affected (v2 has no Cutout_Tallen variant, confirmed
+    # by its absence from the source - a real asymmetry, not an omission).
+    # Previously not ported at all (element_height stored the untallened
+    # value directly, no toggle) - now a real, off-by-default option.
+    g["Tallen"] = e.get("tallen", False)
+    g["Height_Increase"] = e.get("height_increase_mm", 3.0)
+    g["Tallen_Baseline_Offset"] = e.get("tallen_baseline_offset_mm", -1.25)
+    g["Element_Height"] = e["element_height"] + (g["Height_Increase"] if g["Tallen"] else 0.0)
     g["Cylinder_Top_Height_Offset"] = e["cylinder_top_height_offset"]
     g["Cylinder_Top_Chamfer"] = e["cylinder_top_chamfer"]
     g["Cylinder_Top_Diameter"] = e["cylinder_top_diameter"]
@@ -109,7 +138,8 @@ def configure(config_path):
     g["Platen_Fn"] = q.get("platen_fn", GLYPH_DEFAULT_PLATEN_FN)
 
     layout = cfg["layout"]
-    g["BASELINE_ROW"] = layout["baseline_row"]
+    g["BASELINE_ROW"] = ([b + g["Tallen_Baseline_Offset"] for b in layout["baseline_row"]]
+                          if g["Tallen"] else layout["baseline_row"])
     g["CUTOUT_ROW"] = layout["cutout_row"]
     # v2/mignon.scad:120 - Latitude_Int=-360/len(Layout[0]) - NEGATIVE,
     # unlike Blickensderfer/Postal's positive 360/columns. Columns wrap
@@ -122,7 +152,19 @@ def configure(config_path):
     # place_on_cylinder's docstring for what this shifts).
     g["BASELINE_Z_OFFSET"] = 0.0
     g["PLACEMENT_MAP"] = layout["placement_map"]
-    g["DHIATENSOR"] = layout["rows"]
+    # v2/mignon.scad:88,275 - Char_Legend=[7,8,9,10,11,0,1,2,3,4,5,6],
+    # Physical_Layout=[for (row) [for (col) Layout[row][Char_Legend[col]]]].
+    # layout.rows (config, and tune.py's LAYOUT_PRESETS_MIGNON) is stored in
+    # RAW KEYBOARD-LEGEND order (v2's `Layout` - what's printed on the
+    # physical keyboard/manual), so it can be typed/read the way a person
+    # actually reads the legend; DHIATENSOR needs the Char_Legend-remapped
+    # PHYSICAL order (what TextRing/place_on_cylinder actually place by
+    # column index) - this is that remap, applied once here rather than
+    # baked into the stored data, so editing the legend never requires
+    # re-deriving the physical order by hand.
+    char_legend = layout.get("char_legend", list(range(layout["latitude_columns"])))
+    g["CHAR_LEGEND"] = char_legend
+    g["DHIATENSOR"] = [[row[char_legend[c]] for c in range(len(char_legend))] for row in layout["rows"]]
 
     g["PLATEN_RADIUS_MM"] = 1.0 / g["Platen_Diameter"]
 
@@ -233,38 +275,60 @@ def ElementChamfer():
     return sp.union_all([top, frustum])
 
 
-def ElementLabel(points_per_mm=20.0):
-    """v2/mignon.scad:341-355 - the engraved label, placed on
-    ElementChamfer()'s angled chamfer surface (rotate([45,0,90])), not
-    flat on the top face like Blickensderfer/Postal's LogoText() - a
-    genuinely different placement chain, not just different parameter
-    values (see the module docstring). v2's version gets the same small
-    sphere-minkowski rounding LetterText() uses (r=.05, purely a cosmetic
-    edge-softening, not the big draft-cone taper struck characters get) -
-    simplified here to a plain flat extrude, same accepted simplification
-    LogoText() already makes for Blickensderfer/Postal's logo text (see
-    that function's docstring) - fine for a decorative label, not
-    attempted to match exactly."""
-    n_chars = len(Logo_Text)
+def _render_engraved_text(text, text_size, text_spacing, position_offset, height_offset,
+                           font_path, points_per_mm=20.0):
+    """Shared placement chain for ElementLogo()/ElementLabel() - v2/
+    mignon.scad:341-355's ElementLabel(), placed on ElementChamfer()'s
+    angled chamfer surface (rotate([45,0,90])), not flat on the top face
+    like Blickensderfer/Postal's LogoText() - a genuinely different
+    placement chain, not just different parameter values (see the module
+    docstring). v2's version gets the same small sphere-minkowski rounding
+    LetterText() uses (r=.05, purely a cosmetic edge-softening, not the
+    big draft-cone taper struck characters get) - simplified here to a
+    plain flat extrude, same accepted simplification LogoText() already
+    makes for Blickensderfer/Postal's logo text (see that function's
+    docstring) - fine for a decorative label, not attempted to match
+    exactly."""
+    n_chars = len(text)
     parts = []
-    for n, ch in enumerate(Logo_Text):
+    for n, ch in enumerate(text):
         if ch == " ":
             continue
-        mesh = build_flat_text(ch, points_per_mm, 0.09, font_size_mm=Logo_Text_Size,
-                                font_path=LOGO_FONT_PATH)
+        mesh = build_flat_text(ch, points_per_mm, 0.09, font_size_mm=text_size,
+                                font_path=font_path)
         center_x = (mesh.bounds[0][0] + mesh.bounds[1][0]) / 2.0
         mesh.apply_translation([-center_x, 0, 0])
-        angle_n = Logo_Text_Spacing * n + Logo_Position_Offset - (n_chars - 1) * Logo_Text_Spacing / 2
+        angle_n = text_spacing * n + position_offset - (n_chars - 1) * text_spacing / 2
         placed = sp.scad_transform(
             mesh,
             ("rotate", [0, 0, angle_n]),
             ("translate", [Cylinder_Top_Diameter / 2 + Cylinder_Top_Chamfer, 0,
                             Element_Height - Cylinder_Top_Height_Offset]),
             ("rotate", [45, 0, 90]),
-            ("translate", [0, Logo_Height_Offset, -0.05]),
+            ("translate", [0, height_offset, -0.05]),
         )
         parts.append(placed)
     return sp.union_all(parts)
+
+
+def ElementLogo(points_per_mm=20.0):
+    """v2/mignon.scad's actual (only) engraved-text feature - v2 calls
+    this "Cylinder_Label" internally, but it's what Blickensderfer/
+    Postal's config schema and this app's UI call "Logo" (logo.* config
+    keys) for schema-reuse convenience - see configure()'s docstring."""
+    return _render_engraved_text(Logo_Text, Logo_Text_Size, Logo_Text_Spacing,
+                                  Logo_Position_Offset, Logo_Height_Offset,
+                                  LOGO_FONT_PATH, points_per_mm)
+
+
+def ElementLabel(points_per_mm=20.0):
+    """v4-only second engraved-text feature (NOT a v2 concept - see
+    configure()'s docstring) - same placement chain as ElementLogo(),
+    always 180 degrees opposite it (Label_Position_Offset is derived from
+    Logo_Position_Offset, not independently stored)."""
+    return _render_engraved_text(Label_Text, Label_Text_Size, Label_Text_Spacing,
+                                  Label_Position_Offset, Label_Height_Offset,
+                                  LABEL_FONT_PATH, points_per_mm)
 
 
 def MinkCleanup():
@@ -331,7 +395,7 @@ def Additive(points_per_mm=None, separation_mm=None, align_kwargs=None, cone_seg
                               sections=Surface_Fn)
     inner = sp.union_all([text_ring, body])
     cleaned = inner.difference(MinkCleanup(), engine="manifold")
-    return sp.union_all([cleaned, ElementChamfer(), ElementLabel()]), char_parts
+    return sp.union_all([cleaned, ElementChamfer(), ElementLogo(), ElementLabel()]), char_parts
 
 
 def FullElement(points_per_mm=None, separation_mm=None, render_core_groove=None, align_kwargs=None,
@@ -385,7 +449,7 @@ def CalibrationAdditive(test_char=None, vary_baseline=None, vary_cutout=None, st
                               sections=Surface_Fn)
     inner = sp.union_all([text_ring, body])
     cleaned = inner.difference(MinkCleanup(), engine="manifold")
-    return sp.union_all([cleaned, ElementChamfer(), ElementLabel()]), mapping_lines
+    return sp.union_all([cleaned, ElementChamfer(), ElementLogo(), ElementLabel()]), mapping_lines
 
 
 def CalibrationElement(test_char=None, vary_baseline=None, vary_cutout=None, start=None, interval=None,

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -954,7 +954,7 @@ class TuneApp(App):
     #log { height: 1fr; }
     TabbedContent { height: 1fr; }
     TabPane { padding: 0 1; }
-    .field-row { height: 2; }
+    .field-row { height: auto; margin-bottom: 1; }
     .field-row Horizontal { height: 1; }
     .field-label { width: 26; height: 1; content-align: left middle; }
     .field-row Input { width: 1fr; height: 1; border: none; padding: 0 1; background: $panel; }
@@ -962,7 +962,7 @@ class TuneApp(App):
     .field-row Select { width: 1fr; height: 1; border: none; }
     .field-row Select > SelectCurrent { border: none; padding: 0 1; background: $panel; }
     .browse-btn { width: 10; height: 1; min-width: 10; border: none; margin-left: 1; }
-    .field-help { color: $text-muted; height: 1; }
+    .field-help { color: $text-muted; height: auto; }
     #buttons { height: 11; dock: bottom; padding: 0 1; }
     #btn-render-test-text { height: 3; width: 1fr; text-style: bold; margin-bottom: 1; }
     #primary-buttons { height: 5; }
@@ -979,9 +979,9 @@ class TuneApp(App):
     .picker-title { text-style: bold; content-align: center middle; width: auto; margin-bottom: 1; }
     .picker-subtitle { color: $text-muted; content-align: center middle; width: auto; margin-bottom: 1; }
     .machine-picker-btn { width: 30; height: 3; margin-bottom: 1; text-style: bold; }
-    .advanced-warning { color: $warning; text-style: bold; height: 2; padding: 0 0 1 0; }
+    .advanced-warning { color: $warning; text-style: bold; height: auto; padding: 0 0 1 0; }
     .picker-row { height: 3; }
-    .picker-help { color: $text-muted; height: 1; }
+    .picker-help { color: $text-muted; height: auto; }
     .row-preview { height: 1; background: $panel; padding: 0 1; margin-bottom: 1; color: $text-muted; }
     #layout-custom-rows { height: auto; }
     .custom-row-input { height: 1; margin-bottom: 1; border: none; padding: 0 1;

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -506,30 +506,23 @@ SECTIONS_BY_MACHINE = {
 # Static intro banner shown above a section tab's fields, keyed by section
 # name - (text, css class). Only sections that need one appear here.
 SECTION_INTROS = {
-    "Element": ("ADVANCED - real machine dimensions.\nGenerally shouldn't need to change these.",
+    "Element": ("ADVANCED - real machine dimensions. Rarely need changing.",
                 "advanced-warning"),
     "Gauge": (
-        "Shaft Gauge Test (v2's GaugeTestSet()) - a small 6-pocket\n"
-        "calibration test print, NOT part of the real element. Each pocket\n"
-        "bores the shaft passage at offset_start + n*offset_int (n=0..5),\n"
-        "engraved with its own value. Print it, test-fit each numbered\n"
-        "pocket on the real machine's shaft, and set Element > Core ID\n"
-        "offset to whichever number fits. Select \"Shaft Gauge\" on the\n"
-        "Build tab, then Preview/Render as usual to build this instead.",
+        "Small 6-pocket calibration print, not the real element. Each "
+        "pocket bores its shaft passage at offset_start + n*offset_int. "
+        "Test-fit each pocket on the real shaft, then set Element > Core "
+        "ID offset to the best-fitting number. Select \"Shaft Gauge\" on "
+        "the Build tab to build it.",
         "picker-help"),
     "Calibration": (
-        "A real element, but every physical position strikes the SAME\n"
-        "test character, and Vary baselines/Vary cutouts (usually only\n"
-        "one checked at a time) get a different swept value per column\n"
-        "instead of its row's normal value. The sweep is centered on the\n"
-        "MASTER config's baseline/cutout row, not this running copy's -\n"
-        "so it stays a fixed target even after you've already dialed in\n"
-        "a value here. Print it, test-fit each position on the real\n"
-        "machine, and read off which column's value looks/fits best from\n"
-        "the Render log (or the .txt file Save writes alongside the STL)\n"
-        "- then enter it in that row's baseline/cutout field on the\n"
-        "Element tab. Select \"Calibration Element\" on the Build tab,\n"
-        "then Preview/Render as usual to build this instead.",
+        "A real element where every position strikes the same test "
+        "character. Turn on Vary baselines or Vary cutouts (usually just "
+        "one) to sweep that value per column instead of each row's normal "
+        "value, centered on the MASTER config's row so it stays a fixed "
+        "target. Test-fit each column on the real machine, then enter the "
+        "best-fitting value in that row's Element tab field. Select "
+        "\"Calibration Element\" on the Build tab to build it.",
         "picker-help"),
 }
 
@@ -1253,8 +1246,8 @@ class TuneApp(App):
 
     def _compose_baseline_cutout_fields(self):
         yield Static(
-            "Per-row baseline/platen-cutout (mm - see the Calibration tab\n"
-            "for empirically finding these).",
+            "Per-row baseline/platen-cutout (mm). See the Calibration tab "
+            "to find these empirically.",
             classes="picker-help")
         for arr_key, label in (("baseline_row", "Baseline"), ("cutout_row", "Cutout")):
             values = self.cfg["layout"][arr_key]
@@ -1306,35 +1299,31 @@ class TuneApp(App):
                     yield select
                 if self.machine == "blickensderfer":
                     yield Static(
-                        "Ported from v2/lib/layouts/blick_layouts.scad. All share the same\n"
-                        "physical placement_map - only glyph content per row changes.\n"
-                        "HEBREW_ENGL needs a Hebrew-capable font.path to render correctly\n"
-                        "(v2 auto-switches fonts per layout; v4 does not).",
+                        "All layouts share the same physical placement_map - only glyph "
+                        "content per row changes. HEBREW_ENGL needs a Hebrew-capable font "
+                        "path; v4 doesn't auto-switch fonts per layout like v2 did.",
                         classes="picker-help")
                 elif self.machine == "postal":
                     yield Static(
-                        "Postal has only one physical layout (v2/postal.scad has no\n"
-                        "preset-switching menu) - QWERTY is it. Use Modify glyphs below\n"
-                        "to hand-edit the rows if you need something else.",
+                        "Postal has only one physical layout, QWERTY. Use Modify glyphs "
+                        "below to hand-edit the rows for anything else.",
                         classes="picker-help")
                 elif self.machine == "mignon":
                     yield Static(
-                        "Ported from v2/lib/layouts/mignon_layouts.scad (30 real named\n"
-                        "layouts - a few placeholder/never-finished ones in the source\n"
-                        "are excluded). All share the same 7-row/12-column layout -\n"
-                        "only glyph content per row changes. Rows are shown in keyboard-\n"
-                        "legend order (as printed on the physical keyboard/manual) -\n"
-                        "layout.char_legend remaps this to build order internally.",
+                        "30 named layouts, all sharing the same 7-row/12-column physical "
+                        "layout - only glyph content changes per row. Rows are shown in "
+                        "keyboard-legend order; char_legend remaps this to build order "
+                        "internally.",
                         classes="picker-help")
                 elif options:
                     yield Static(
-                        "Use Modify glyphs below to hand-edit the rows if you need\n"
-                        "something other than the selected preset.",
+                        "Use Modify glyphs below to hand-edit the rows for anything "
+                        "other than the selected preset.",
                         classes="picker-help")
                 else:
                     yield Static(
-                        "No named layout presets for this machine yet - use Modify glyphs\n"
-                        "below to hand-edit the rows directly.",
+                        "No named layout presets yet - use Modify glyphs below to edit "
+                        "the rows directly.",
                         classes="picker-help")
 
                 yield Static("Rows (read-only preview of the preset above):", classes="field-label")
@@ -1349,11 +1338,9 @@ class TuneApp(App):
                     sw = Switch(value=modify_now, id="layout-modify-glyphs")
                     yield sw
                 yield Static(
-                    f"Unlocks a hand-editable copy of the {len(display_rows)} rows below,\n"
-                    f"capped at {char_cap} characters each (placement_map's length - more\n"
-                    "than that would crash TextRing). Fewer than that just leaves some\n"
-                    "physical positions unstruck. While on, this edited copy - not the\n"
-                    "preset dropdown above - is what gets saved to layout.rows.",
+                    f"Unlocks {len(display_rows)} hand-editable rows, max {char_cap} "
+                    "characters each. Shorter rows just leave some positions unstruck. "
+                    "While on, this edited copy (not the preset above) is what gets saved.",
                     classes="picker-help")
 
                 custom_rows_container = Vertical(id="layout-custom-rows")
@@ -1387,30 +1374,26 @@ class TuneApp(App):
                     sw = Switch(value=resin_now, id="build-resin-support")
                     yield sw
                 gauge_help = (
-                    " Shaft\nGauge = GaugeTestSet() (see the Gauge tab) - a calibration test\n"
-                    "print, not part of the real element; always has its own resin\n"
-                    "supports built in regardless of this checkbox."
+                    " Shaft Gauge: a small calibration print (see the Gauge tab) - "
+                    "always includes its own resin supports regardless of this "
+                    "checkbox."
                 ) if has_gauge else ""
                 yield Static(
-                    "Element = FullElement(), or ResinPrint() (adds ResinSupport()'s\n"
-                    "rods/breakaway ring) if Resin supports is on - see the Resin tab\n"
-                    "for its own settings, which only matter when this is on."
-                    f"{gauge_help} Calibration\n"
-                    "Element = a real element with the SAME test character struck at\n"
-                    "every position, sweeping baseline or platen cutout per column\n"
-                    "(see the Calibration tab) - for empirically finding\n"
-                    "layout.baseline_row/cutout_row.",
+                    "Element: the real element. Turn on Resin supports to add "
+                    "rods/breakaway ring (see the Resin tab for those settings)."
+                    f"{gauge_help} Calibration Element: strikes the same test "
+                    "character everywhere, sweeping baseline or cutout per column "
+                    "(see the Calibration tab) to find layout.baseline_row/cutout_row.",
                     classes="picker-help")
 
     def _compose_type_test_tab(self):
         with TabPane("Type Test", id="tab-type-test"):
             with VerticalScroll():
                 yield Static(
-                    "Flat, fixed-pitch (CPI) test block - matches v2's TypeTest()\n"
-                    "spacing convention. Uses the Font tab's path/size. NOT part of\n"
-                    "the real element - overwrites the same scratch output STL as\n"
-                    "Render/Quick Preview, so the same f3d --watch window shows it.\n"
-                    "Multiple lines are supported (stacked vertically).",
+                    "Flat, fixed-pitch (CPI) test block using the Font tab's "
+                    "path/size. Not part of the real element - overwrites the same "
+                    "scratch STL as Render/Quick Preview, so the same f3d window "
+                    "shows it. Supports multiple lines, stacked vertically.",
                     classes="picker-help")
                 yield Static("Test text", classes="field-label")
                 yield TextArea(self.cfg["type_test"]["text"], id="type-test-text")

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -197,10 +197,11 @@ YAML_FILE_FILTERS = Filters(
     ("YAML files", lambda p: p.suffix.lower() in (".yaml", ".yml")),
     ("All files", lambda _: True),
 )
-# font.path (Font & Alignment tab) and logo.font_path (Logo tab) are the
-# only two font-picking fields - both get a "Browse" button, see
+# font.path (Font & Alignment tab), logo.font_path (Logo tab), and Mignon's
+# label.font_path (Logo tab, label_font_path key - see LOGO_FIELDS_MIGNON)
+# are the font-picking fields - each gets a "Browse" button, see
 # _compose_section_tab and on_button_pressed's "browse-" id handling
-FONT_PATH_FIELD_KEYS = ("path", "font_path")
+FONT_PATH_FIELD_KEYS = ("path", "font_path", "label_font_path")
 
 # Named Blickensderfer keyboard layouts, ported verbatim from
 # v2/lib/layouts/blick_layouts.scad's DHIATENSOR/QWERTY/SCANDI/
@@ -354,15 +355,33 @@ GAUGE_FIELDS = [
 # Mignon-specific tabs - see lib/mignon.py's module docstring for why
 # these can't share Blickensderfer/Postal's field lists.
 LOGO_FIELDS_MIGNON = [
-    ("font_path", ["logo", "font_path"], str, "Logo font path", "Font for the engraved ElementLabel."),
+    ("font_path", ["logo", "font_path"], str, "Logo font path", "Font for the engraved ElementLogo."),
     ("text", ["logo", "text"], str, "Logo text", "The engraved text itself."),
     ("text_size_mm", ["logo", "text_size_mm"], float, "Logo text size (mm)", ""),
     ("text_spacing", ["logo", "text_spacing"], float, "Logo char spacing (deg)", "Angular spacing between logo characters."),
-    ("position_offset_deg", ["logo", "position_offset_deg"], float, "Logo position offset (deg)", ""),
+    ("position_offset_deg", ["logo", "position_offset_deg"], float, "Logo position offset (deg)",
+     "The Label fields below always sit 180 degrees opposite this value - "
+     "moving Logo also moves Label."),
     ("height_offset_mm", ["logo", "height_offset_mm"], float, "Logo height offset (mm)",
-     "Local nudge off the chamfer surface the label sits on - NOT the "
+     "Local nudge off the chamfer surface the logo sits on - NOT the "
      "same concept as Blickensderfer/Postal's radial offset (Mignon's "
-     "label sits on an angled chamfer surface, not the flat top face)."),
+     "logo/label sit on an angled chamfer surface, not the flat top face)."),
+    # Label: not a v2 concept - a second engraved-text feature, same
+    # format as Logo above, always placed 180 degrees opposite it (no
+    # position_offset_deg field here - it's derived, see logo's help text
+    # above and lib/mignon.py's configure()). Keys prefixed label_* since
+    # "font_path"/"text"/etc. above are already taken by Logo's own fields
+    # (self.inputs keys must be unique within one machine's field set) -
+    # AND the actual config/mignon.yaml keys are also prefixed label_*, not
+    # just these internal field keys: patch_yaml_value matches by bare key
+    # TEXT across the whole file, not by section, so identical YAML key
+    # names under logo:/label: would collide and patch the wrong one.
+    ("label_font_path", ["label", "label_font_path"], str, "Label font path", "Font for the engraved ElementLabel."),
+    ("label_text", ["label", "label_text"], str, "Label text", "The engraved text itself."),
+    ("label_text_size_mm", ["label", "label_text_size_mm"], float, "Label text size (mm)", ""),
+    ("label_text_spacing", ["label", "label_text_spacing"], float, "Label char spacing (deg)", "Angular spacing between label characters."),
+    ("label_height_offset_mm", ["label", "label_height_offset_mm"], float, "Label height offset (mm)",
+     "Local nudge off the chamfer surface the label sits on."),
 ]
 
 QUALITY_FIELDS_MIGNON = [
@@ -392,7 +411,17 @@ ELEMENT_FIELDS_MIGNON = [
     ("platen_diameter", ["element", "platen_diameter"], float, "Platen diameter (mm)", ""),
     ("min_final_character_diameter", ["element", "min_final_character_diameter"], float,
      "Min final char diameter (mm)", "Char_Protrusion = (this - element_diameter)/2."),
-    ("element_height", ["element", "element_height"], float, "Element height (mm)", ""),
+    ("element_height", ["element", "element_height"], float, "Base element height (mm)",
+     "Cylinder_Height_ - the untallened height. Actual built height adds "
+     "height_increase_mm below when Tallen is on."),
+    ("tallen", ["element", "tallen"], bool, "Tallen (Plakatschrift)",
+     "Display-type variant: adds height_increase_mm to element height and "
+     "shifts every baseline row by tallen_baseline_offset_mm. Cutout rows "
+     "are unaffected. Off for a standard element."),
+    ("height_increase_mm", ["element", "height_increase_mm"], float, "Tallen height increase (mm)",
+     "Added to base element height when Tallen is on."),
+    ("tallen_baseline_offset_mm", ["element", "tallen_baseline_offset_mm"], float, "Tallen baseline offset (mm)",
+     "Added to every baseline row when Tallen is on."),
     ("cylinder_top_height_offset", ["element", "cylinder_top_height_offset"], float, "Top height offset (mm)", ""),
     ("cylinder_top_chamfer", ["element", "cylinder_top_chamfer"], float, "Top chamfer size (mm)", ""),
     ("cylinder_top_diameter", ["element", "cylinder_top_diameter"], float, "Top diameter (mm)", ""),
@@ -516,16 +545,312 @@ LAYOUT_PRESETS_POSTAL = {
     ],
 }
 
+# Mignon's 30 real named layouts from v2/lib/layouts/mignon_layouts.scad's
+# Layouts=[] array (33 total minus 3 empty placeholders - CUSTOMLAYOUT,
+# DEUTSCH_FRAKTUR_GOTISCH, DEUTSCH_FRAKTUR_PROF_STIEHL - all-empty-string
+# rows in the real source, never finished/used there either). A few source
+# rows had a 13th character v2 itself never reads (Char_Legend only ever
+# indexes 0-11) - truncated to 12 to match what v2 actually uses (Georgian
+# rows 2/4, Greek rows 3/4).
+#
+# Stored here in RAW KEYBOARD-LEGEND order - i.e. v2's own `Layout` array,
+# exactly as printed on the physical keyboard/manual - NOT the Char_Legend-
+# remapped `Physical_Layout` order used for actual glyph placement. The two
+# differ by a fixed rotation: physical = keyboard[7:12] + keyboard[0:7]
+# (Char_Legend=[7,8,9,10,11,0,1,2,3,4,5,6]), equivalently keyboard =
+# physical[5:] + physical[:5] - the exact "move the first 5 characters to
+# the end" transform the user asked for, applied once here to what used to
+# be stored (physical order, from the original import) to reach the
+# canonical keyboard-legend representation. mignon.py's configure() applies
+# the Char_Legend remap itself when loading layout.rows into DHIATENSOR, so
+# the actual built geometry is unchanged - only this display/edit
+# representation moved to match what a person reads off the machine.
+LAYOUT_PRESETS_MIGNON = {
+    'English 2': [
+        '\'"%&(£$);:,.',
+        '?PFUGQpfugq¼',
+        '!VINABvinab½',
+        '_LDETMldetm¾',
+        'JKOSRZkosrzj',
+        '/YCHWXychwx@',
+        '#1234567890-',
+    ],
+    'English 3': [
+        '()&\'".,:¼½¾⅛',
+        '?PFUGQpfugq⅜',
+        '=VINABvinab⅝',
+        '+LDETMldetm⅞',
+        'JKOSRZkosrzj',
+        '/YCHWXychwx_',
+        '£23456789%@-',
+    ],
+    'English 4': [
+        '()&\'".,:¼½¾⅛',
+        '?PFUGQpfugq⅜',
+        '=VINABvinab⅝',
+        '$LDETMldetm⅞',
+        'JKOSRZkosrzj',
+        '/YCHWXychwx_',
+        '£23456789%@-',
+    ],
+    'German 2': [
+        '§%&():,.äöü¾',
+        '"PFUGQpfugq½',
+        '?VINABvinab¼',
+        "_LDETMldetm'",
+        'JKOSRZkosrzj',
+        '/YCHWXychwx!',
+        '„1234567890-',
+    ],
+    'German 4': [
+        '&():"!?\'äöü_',
+        '§PFUGQpfugq;',
+        'JVINABvinabj',
+        '/LDETMldetm,',
+        '%KOSRZkosrz=',
+        '¾YCHWXychwx+',
+        '½¼23456789.-',
+    ],
+    'German-French': [
+        '§%&():,.äöüè',
+        '"PFUGQpfugqà',
+        '?VINABvinabé',
+        "_LDETMldetm'",
+        'JKOSRZkosrzj',
+        '/YCHWXychwxç',
+        '^1234567890-',
+    ],
+    'Bohemian 3': [
+        '!?´%23456789',
+        'PFUGJpfugjů"',
+        'VNIABvniabíá',
+        'LDETMldetméě',
+        'KOSRZkosrzšř',
+        'YCHWXychwxžú',
+        '&ˇ§Qqýč/,:.-',
+    ],
+    'Bulgarian': [
+        '§ЮЯЛЦVюялць&',
+        '№ПРХСУпрхсуй',
+        '/ЩШКАМщшкам!',
+        'ЗОВЪТѢовътѣз',
+        '%ГИНЕДгинед?',
+        'IЖФѪБЧжфѫбч"',
+        '2456789.-,;:',
+    ],
+    'Cyrillic': [
+        '§%№VI:"!,?=-',
+        'ЂПФУГJпфугjђ',
+        'ЧВИНАБвинабч',
+        'ШЛДЕТМлдетмш',
+        'ЋКОСРЗкосрзћ',
+        'ЏЉЦХЊЖљцхњжџ',
+        '/123456789._',
+    ],
+    'Danish 2': [
+        'Æ§&?()_\'¨:"æ',
+        'ØPFUGQpfugqø',
+        'JVINABvinabj',
+        '%LDETMldetm,',
+        '/KOSRZkosrz÷',
+        '¼YCHWXychwx+',
+        '½¾23456789.-',
+    ],
+    'Danish 3': [
+        'Æ§&?()_\'¨:"æ',
+        'ØPFUGQpfugqø',
+        'JVINABvinabj',
+        '%LDETMldetm,',
+        '/KOSRZkosrz÷',
+        '¼YCHWXychwx+',
+        '½¾23456789.=',
+    ],
+    'Esperanto': [
+        '()23456789é"',
+        "'PFUGQpfugq:",
+        '!VINABvinab.',
+        '?LDETMldetm,',
+        'JKOSRZkosrzj',
+        '^YCHWXychwx-',
+        'ĴŜĈĤĜŬŝĉĥĝŭĵ',
+    ],
+    'French 3': [
+        'K&()?:,"_çùk',
+        'WJFQBYjfqbyw',
+        '§VNIAPvniapà',
+        "/DOUT'doutéè",
+        '%CSERGcserg^',
+        '½HLMZXhlmzx+',
+        '¼23456789.-=',
+    ],
+    'Georgian': [
+        '[]!":.,-;?*\'',
+        'IV&წძცყქღჷა^',
+        'XCგბეიულტჲ¨=',
+        'LDჩუმდაႱზჱ§,',
+        '$Mჴვროთხნჵჶ№',
+        '£§ჰჭჟჯფპკ#ჳ/',
+        '1234567890%½',
+    ],
+    'Greek (new ortography)': [
+        '£123456789-;',
+        "&ΠΡΚΓΞπρκγξ'",
+        '½ΛΤΗΑΒλτηαβ͂',
+        '¼ΜΔΕΝΨμδενψ̇',
+        '_ΘΟΥΙΖθουιζ.',
+        '%ΧΩΣͅΦχωσϛφ,',
+        '$()/„῟῞῏῎´᾿¨',
+    ],
+    'Dutch 2': [
+        '&():"?\'¨`^´_',
+        '£PFUGQpfugqĳ',
+        'JVINABvinabj',
+        '/LDETMldetm,',
+        '%KOSRZkosrz+',
+        '¾YCHWXychwx=',
+        '½¼2345ƒ6789.',
+    ],
+    'Italian 3': [
+        '"%&()^àèìòùé',
+        '?WFUGQwfugq!',
+        'JVINABvinabj',
+        "_LDETMldetm'",
+        '=KOSRZkosrz,',
+        '/YCHPXychpx:',
+        '+º23456789.-',
+    ],
+    'Croatian-Slovenian': [
+        '%+=_:,.!?"-´',
+        '&PFUGKpfugkć',
+        'QVINAJvinajq',
+        'ĐLDETMldetmđ',
+        '§ČOSŠZčosšz/',
+        'WBCHRŽbchržw',
+        'YX23456789xy',
+    ],
+    'Latvian': [
+        '32ļģŗņķ?!=/̦',
+        '4PFUGCpfugc"',
+        '5VINABvinab-',
+        '6LDETMldetm,',
+        '7KOSRZkosrz.',
+        '8HJX%§hjxāūē',
+        '9ČŠŽ()čšžī:̄',
+    ],
+    'Lithuanian': [
+        "!'23456789;-",
+        'ŲPFUGĄpfugąų',
+        'ĮVINABvinabį',
+        ',LDETMldetm?',
+        '_KOSĘZkosęz/',
+        '.YCHRJychrj"',
+        '%ŽĖŠČŪžėščū§',
+    ],
+    'Polish 2': [
+        '?§&óśńźćąę\'"',
+        '%PFUGQpfugq!',
+        'ŻVINABvinabż',
+        'ŁLDETMldetmł',
+        'JKOSRZkosrzj',
+        '/YCHWXychwx,',
+        '|:23456789.-',
+    ],
+    'Portuguese 2': [
+        '&?Ç!º̃áéêóç#',
+        '%PFUGQpfugq£',
+        ':VINABvinab$',
+        '(LDETMldetm)',
+        'JKOSRZkosrzj',
+        "'YCHWXychwx,",
+        '"/23456789.-',
+    ],
+    'Romanian 1': [
+        '§W()"?w\';:!_',
+        '&KFOMHkfomhî',
+        '/DCESBdcesbș',
+        '=GPARUgparuă',
+        '+LTINVltinvț',
+        '%YXJZQyxjzqâ',
+        '½23456789,.-',
+    ],
+    'Russian (new ortography)': [
+        '№ХЬЯЛУхьялу!',
+        '1ТГСЮЙтгсюй/',
+        '2РПОИЫрпоиы"',
+        '3ЧВЕНДчвендз',
+        "4ЦАМКБцамкб'",
+        '5ЖЩШЭФжщшэф.',
+        '6789%$£§/,:-',
+    ],
+    'Russian 3': [
+        'ЭХЯЛЬГэхяльг',
+        'ОПРСЮУпрсюуо',
+        'IЩШЧТНщшчтнi',
+        'ЗФЦКАЕфцкаез',
+        '2БИМВДбимвд?',
+        '4ЖЙЫЪѢжйыъѣ!',
+        '56789№§.-:,/',
+    ],
+    'Spanish-American': [
+        '&?¿!¡;áéíóúñ',
+        '%PFUGQpfugq£',
+        ':VINABvinab$',
+        '(LDETMldetm)',
+        'JKOSRZkosrzj',
+        "'YCHWXychwx,",
+        '"/23456789.-',
+    ],
+    'International Script': [
+        '123456789-,_',
+        '&PFUGQpfugq.',
+        'JVINABvinabj',
+        '=LDETMldetmé',
+        '%KOSRZkosrzç',
+        '/YCHWXychwx:',
+        '§!?()"´`^ˇ˚˜',
+    ],
+    'Swedish 2': [
+        '§()ÄÖ:"\',äö+',
+        'QPFUGÅpfugåq',
+        '?VINABvinab=',
+        '&LDETMldetm_',
+        '%KOSRJkosrj.',
+        'XYCHWZychwzx',
+        '/¼½¾23456789',
+    ],
+    'Ukrainian': [
+        'ҐХЯЛЬГґхяльг',
+        "%ПРСЮУпрсюу'",
+        'IЩШЧТНщшчтнi',
+        '2ФЦКАЕфцкае?',
+        'ЗБИМВДбимвдз',
+        '4ЖОЙЄЇжойєї!',
+        '56789№§.-:,/',
+    ],
+    'Hungarian 2': [
+        '?:!"ÖÜ,űőöüú',
+        'ÉPFUGYpfugyé',
+        'ÓVINABvinabó',
+        'ÁLDETMldetmá',
+        'JKOSRZkosrzj',
+        '/QCHWXqchwx.',
+        '+%23456789§-',
+    ],
+}
+
 LAYOUT_PRESETS_BY_MACHINE = {
     "blickensderfer": LAYOUT_PRESETS,
     "postal": LAYOUT_PRESETS_POSTAL,
+    "mignon": LAYOUT_PRESETS_MIGNON,
 }
 
 # layout.baseline_row/cutout_row per-row fields (Element tab - see
 # TuneApp._compose_baseline_cutout_fields). Bespoke, not in
 # self.FIELDS/SECTIONS - these are list ELEMENTS (patch_yaml_list_item),
-# not standalone scalar YAML keys patch_yaml_value can patch.
-BASELINE_CUTOUT_KEYS = [f"{arr}_{i}" for arr in ("baseline_row", "cutout_row") for i in range(3)]
+# not standalone scalar YAML keys patch_yaml_value can patch. Row count
+# varies per machine (3 for Blickensderfer/Postal, 7 for Mignon), so
+# self.BASELINE_CUTOUT_KEYS is computed per-instance in _load_machine(),
+# not a fixed module constant - see there.
 
 
 def get_nested(d, path):
@@ -581,7 +906,9 @@ def patch_yaml_list_item(text, key, index, value):
 
 
 def patch_yaml_rows(text, rows):
-    """layout.rows is a 3-item YAML block list, not a single-line scalar -
+    """layout.rows is a multi-item YAML block list (3 items for
+    Blickensderfer/Postal, 7 for Mignon - row-count-agnostic here, just
+    writes however many items `rows` has), not a single-line scalar -
     patch_yaml_value's one-token regex doesn't apply. Matches the `rows:`
     line plus every immediately-following more-indented `- "..."` line
     and replaces the whole block, preserving the existing indent style."""
@@ -719,6 +1046,10 @@ class TuneApp(App):
         self.SECTIONS = SECTIONS_BY_MACHINE.get(self.machine, SECTIONS_BY_MACHINE["blickensderfer"])
         self.FIELDS = [field for fields in self.SECTIONS.values() for field in fields]
         self.LAYOUT_PRESETS = LAYOUT_PRESETS_BY_MACHINE.get(self.machine, {})
+        # row count varies per machine (3 for Blickensderfer/Postal, 7 for
+        # Mignon) - see BASELINE_CUTOUT_KEYS' module comment
+        n_rows = len(self.cfg["layout"]["baseline_row"])
+        self.BASELINE_CUTOUT_KEYS = [f"{arr}_{i}" for arr in ("baseline_row", "cutout_row") for i in range(n_rows)]
 
     @staticmethod
     def _running_config_path(master_path):
@@ -909,20 +1240,27 @@ class TuneApp(App):
     # not in self.FIELDS - _collect_values/_save_to_yaml/
     # _refresh_widgets_from_cfg handle them explicitly, same pattern as
     # the Layout/Type Test tabs' own bespoke widgets.
+    # Only meaningful for Blickensderfer/Postal's 3 real shift rows
+    # (lowercase/uppercase/figs) - Mignon's 7 rows have no such semantic
+    # names (v2 itself has no per-row label concept, see
+    # lib/glyph_pipeline.scad's Row_Labels comment: "default: numeric
+    # 'row N'" for machines with no 3-entry meaning). Rows beyond this
+    # list's length just show as "Row N" with no parenthetical.
     ROW_LABELS = ["lowercase", "uppercase", "figs"]
 
     def _compose_baseline_cutout_fields(self):
         yield Static(
-            "Per-row baseline/platen-cutout (mm below the clip end) - see\n"
-            "the Calibration tab for empirically finding these.",
+            "Per-row baseline/platen-cutout (mm - see the Calibration tab\n"
+            "for empirically finding these).",
             classes="picker-help")
         for arr_key, label in (("baseline_row", "Baseline"), ("cutout_row", "Cutout")):
             values = self.cfg["layout"][arr_key]
-            for i, row_label in enumerate(self.ROW_LABELS):
+            for i in range(len(values)):
                 key = f"{arr_key}_{i}"
+                row_label = f" ({self.ROW_LABELS[i]})" if i < len(self.ROW_LABELS) else ""
                 with Vertical(classes="field-row"):
                     with Horizontal():
-                        yield Static(f"{label} row {i} ({row_label})", classes="field-label")
+                        yield Static(f"{label} row {i}{row_label}", classes="field-label")
                         inp = Input(value=str(values[i]), id=f"field-{key}")
                         self.inputs[key] = inp
                         yield inp
@@ -970,21 +1308,35 @@ class TuneApp(App):
                         "HEBREW_ENGL needs a Hebrew-capable font.path to render correctly\n"
                         "(v2 auto-switches fonts per layout; v4 does not).",
                         classes="picker-help")
-                elif options:
+                elif self.machine == "postal":
                     yield Static(
                         "Postal has only one physical layout (v2/postal.scad has no\n"
                         "preset-switching menu) - QWERTY is it. Use Modify glyphs below\n"
-                        "to hand-edit the 3 rows if you need something else.",
+                        "to hand-edit the rows if you need something else.",
+                        classes="picker-help")
+                elif self.machine == "mignon":
+                    yield Static(
+                        "Ported from v2/lib/layouts/mignon_layouts.scad (30 real named\n"
+                        "layouts - a few placeholder/never-finished ones in the source\n"
+                        "are excluded). All share the same 7-row/12-column layout -\n"
+                        "only glyph content per row changes. Rows are shown in keyboard-\n"
+                        "legend order (as printed on the physical keyboard/manual) -\n"
+                        "layout.char_legend remaps this to build order internally.",
+                        classes="picker-help")
+                elif options:
+                    yield Static(
+                        "Use Modify glyphs below to hand-edit the rows if you need\n"
+                        "something other than the selected preset.",
                         classes="picker-help")
                 else:
                     yield Static(
                         "No named layout presets for this machine yet - use Modify glyphs\n"
-                        "below to hand-edit the 3 rows directly.",
+                        "below to hand-edit the rows directly.",
                         classes="picker-help")
 
                 yield Static("Rows (read-only preview of the preset above):", classes="field-label")
                 display_rows = self._display_rows_for_preset()
-                for i in range(3):
+                for i in range(len(display_rows)):
                     static = Static(display_rows[i], id=f"layout-original-row-{i}", classes="row-preview")
                     yield static
 
@@ -994,18 +1346,18 @@ class TuneApp(App):
                     sw = Switch(value=modify_now, id="layout-modify-glyphs")
                     yield sw
                 yield Static(
-                    f"Unlocks a hand-editable copy of the 3 rows below, capped at\n"
-                    f"{char_cap} characters each (placement_map's length - more than that\n"
-                    "would crash TextRing). Fewer than that just leaves some physical\n"
-                    "positions unstruck. While on, this edited copy - not the preset\n"
-                    "dropdown above - is what gets saved to layout.rows.",
+                    f"Unlocks a hand-editable copy of the {len(display_rows)} rows below,\n"
+                    f"capped at {char_cap} characters each (placement_map's length - more\n"
+                    "than that would crash TextRing). Fewer than that just leaves some\n"
+                    "physical positions unstruck. While on, this edited copy - not the\n"
+                    "preset dropdown above - is what gets saved to layout.rows.",
                     classes="picker-help")
 
                 custom_rows_container = Vertical(id="layout-custom-rows")
                 custom_rows_container.display = modify_now
                 with custom_rows_container:
                     current_rows = self.cfg["layout"]["rows"]
-                    for i in range(3):
+                    for i in range(len(current_rows)):
                         inp = Input(value=current_rows[i], id=f"layout-custom-row-{i}",
                                     max_length=char_cap, classes="custom-row-input")
                         yield inp
@@ -1167,7 +1519,7 @@ class TuneApp(App):
         # bespoke like everything above, since they're list elements, not
         # standalone scalar YAML keys - see BASELINE_CUTOUT_KEYS/
         # patch_yaml_list_item.
-        for key in BASELINE_CUTOUT_KEYS:
+        for key in self.BASELINE_CUTOUT_KEYS:
             raw = self.inputs[key].value.strip()
             try:
                 values[key] = float(raw)
@@ -1180,10 +1532,10 @@ class TuneApp(App):
         with open(self.config_path) as f:
             text = f.read()
         for key, value in values.items():
-            if key in BASELINE_CUTOUT_KEYS:
+            if key in self.BASELINE_CUTOUT_KEYS:
                 continue
             text = patch_yaml_value(text, key, value)
-        for key in BASELINE_CUTOUT_KEYS:
+        for key in self.BASELINE_CUTOUT_KEYS:
             arr_key, index_str = key.rsplit("_", 1)
             text = patch_yaml_list_item(text, arr_key, int(index_str), values[key])
         modify_glyphs = self.query_one("#layout-modify-glyphs", Switch).value
@@ -1194,7 +1546,8 @@ class TuneApp(App):
             # row to the placement_map cap in case anything bypassed the
             # Input's own max_length (e.g. a paste)
             char_cap = len(self.cfg["layout"]["placement_map"])
-            custom_rows = [self.query_one(f"#layout-custom-row-{i}", Input).value[:char_cap] for i in range(3)]
+            n_rows = len(self.cfg["layout"]["rows"])
+            custom_rows = [self.query_one(f"#layout-custom-row-{i}", Input).value[:char_cap] for i in range(n_rows)]
             text = patch_yaml_rows(text, custom_rows)
         else:
             layout_select = self.query_one("#layout-select", Select)
@@ -1244,17 +1597,17 @@ class TuneApp(App):
         self.query_one("#type-test-lpi", Input).value = str(self.cfg["type_test"]["lpi"])
         self.query_one("#type-test-text", TextArea).text = self.cfg["type_test"]["text"]
         display_rows = self._display_rows_for_preset()
-        for i in range(3):
+        for i in range(len(display_rows)):
             self.query_one(f"#layout-original-row-{i}", Static).update(display_rows[i])
         modify_glyphs = bool(self.cfg["layout"]["modify_glyphs"])
         self.query_one("#layout-modify-glyphs", Switch).value = modify_glyphs
         self.query_one("#layout-custom-rows").display = modify_glyphs
         current_rows = self.cfg["layout"]["rows"]
-        for i in range(3):
+        for i in range(len(current_rows)):
             self.query_one(f"#layout-custom-row-{i}", Input).value = current_rows[i]
         for arr_key in ("baseline_row", "cutout_row"):
             arr = self.cfg["layout"][arr_key]
-            for i in range(3):
+            for i in range(len(arr)):
                 self.inputs[f"{arr_key}_{i}"].value = str(arr[i])
 
     def action_reload(self):
@@ -1571,7 +1924,7 @@ class TuneApp(App):
         # self.cfg only updates on an actual save, so that would have
         # kept showing the OLD preset while just browsing the dropdown.
         display_rows = self._rows_for_layout_select_value(event.value)
-        for i in range(3):
+        for i in range(len(display_rows)):
             self.query_one(f"#layout-original-row-{i}", Static).update(display_rows[i])
 
     def on_switch_changed(self, event: Switch.Changed) -> None:
@@ -1586,7 +1939,7 @@ class TuneApp(App):
             # "custom"), so it starts as an exact copy to hand-edit from
             layout_select_value = self.query_one("#layout-select", Select).value
             display_rows = self._rows_for_layout_select_value(layout_select_value)
-            for i in range(3):
+            for i in range(len(display_rows)):
                 self.query_one(f"#layout-custom-row-{i}", Input).value = display_rows[i]
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -360,22 +360,25 @@ LOGO_FIELDS_MIGNON = [
     ("text_size_mm", ["logo", "text_size_mm"], float, "Logo text size (mm)", ""),
     ("text_spacing", ["logo", "text_spacing"], float, "Logo char spacing (deg)", "Angular spacing between logo characters."),
     ("position_offset_deg", ["logo", "position_offset_deg"], float, "Logo position offset (deg)",
-     "The Label fields below always sit 180 degrees opposite this value - "
-     "moving Logo also moves Label."),
+     "The Label tab's own text always sits 180 degrees opposite this "
+     "value - moving Logo also moves Label."),
     ("height_offset_mm", ["logo", "height_offset_mm"], float, "Logo height offset (mm)",
      "Local nudge off the chamfer surface the logo sits on - NOT the "
      "same concept as Blickensderfer/Postal's radial offset (Mignon's "
      "logo/label sit on an angled chamfer surface, not the flat top face)."),
-    # Label: not a v2 concept - a second engraved-text feature, same
-    # format as Logo above, always placed 180 degrees opposite it (no
-    # position_offset_deg field here - it's derived, see logo's help text
-    # above and lib/mignon.py's configure()). Keys prefixed label_* since
-    # "font_path"/"text"/etc. above are already taken by Logo's own fields
-    # (self.inputs keys must be unique within one machine's field set) -
-    # AND the actual config/mignon.yaml keys are also prefixed label_*, not
-    # just these internal field keys: patch_yaml_value matches by bare key
-    # TEXT across the whole file, not by section, so identical YAML key
-    # names under logo:/label: would collide and patch the wrong one.
+]
+
+# Label: not a v2 concept - a second engraved-text feature, own tab, same
+# field format as Logo above, always placed 180 degrees opposite it (no
+# position_offset_deg field here - it's derived, see Logo's help text
+# above and lib/mignon.py's configure()). Keys prefixed label_* since
+# "font_path"/"text"/etc. above are already taken by Logo's own fields
+# (self.inputs keys must be unique within one machine's field set) - AND
+# the actual config/mignon.yaml keys are also prefixed label_*, not just
+# these internal field keys: patch_yaml_value matches by bare key TEXT
+# across the whole file, not by section, so identical YAML key names
+# under logo:/label: would collide and patch the wrong one.
+LABEL_FIELDS_MIGNON = [
     ("label_font_path", ["label", "label_font_path"], str, "Label font path", "Font for the engraved ElementLabel."),
     ("label_text", ["label", "label_text"], str, "Label text", "The engraved text itself."),
     ("label_text_size_mm", ["label", "label_text_size_mm"], float, "Label text size (mm)", ""),
@@ -495,7 +498,7 @@ SECTIONS_BY_MACHINE = {
     # ELEMENT_FIELDS_MIGNON's neighboring comment) - compose()/
     # _compose_build_tab() check for its absence and skip the tab/dropdown
     # option accordingly, rather than every machine being forced to have one.
-    "mignon": {**SECTIONS_COMMON, "Logo": LOGO_FIELDS_MIGNON,
+    "mignon": {**SECTIONS_COMMON, "Logo": LOGO_FIELDS_MIGNON, "Label": LABEL_FIELDS_MIGNON,
                "Quality": QUALITY_FIELDS_MIGNON, "Resin": RESIN_FIELDS_MIGNON,
                "Element": ELEMENT_FIELDS_MIGNON},
 }
@@ -1460,6 +1463,8 @@ class TuneApp(App):
                 yield from self._compose_layout_tab()
                 yield from self._compose_section_tab("Quality")
                 yield from self._compose_section_tab("Logo")
+                if "Label" in self.SECTIONS:
+                    yield from self._compose_section_tab("Label")
                 yield from self._compose_section_tab("Element")
 
             with Vertical(id="buttons"):


### PR DESCRIPTION
## Summary
- `.field-help`, `.picker-help`, and `.advanced-warning` were pinned to a fixed height (1 or 2 rows), so any help/tooltip text longer than that got clipped instead of wrapping.
- Most notably, the Gauge and Calibration tab intro banners are authored as 7-9 line strings but were rendered squashed into a single visible line.
- Switched those classes to `height: auto`; `.field-row` also moved to `height: auto` (with `margin-bottom: 1` to preserve the previous field spacing) so its help text can grow the row.

## Test plan
- [x] `python -c "import tune"` — CSS parses without error
- [x] Headless `App.run_test()` — confirmed `.picker-help` regions on Gauge/Calibration tabs now render at height 7 and 9 (matching their full text), and a `.field-help` element now wraps to 2 lines, where before all were clamped to height 1
- [ ] Manual check in a real terminal (not run here)