### PR TITLE
v4: revise CLAUDE.md porting conventions, fix docstring/tune.py drift

### DIFF
--- a/v4/CLAUDE.md
+++ b/v4/CLAUDE.md
@@ -4,11 +4,11 @@
 
 Search `lib/cylinder_machine.py` (shared across cylinder machines) and the
 target machine's own module (`lib/blickensderfer.py`, `lib/postal.py`,
-`lib/mignon.py`, `lib/glyph_poc.py`, `lib/scad_primitives.py`) for an
-existing function that already does what you're about to write before
-adding a new one. Duplicated logic is how the two machines drift out of
-sync silently - see "Porting a new machine" below for the same failure
-mode at the machine-port level.
+`lib/mignon.py`, `lib/bennett.py`, `lib/glyph_poc.py`,
+`lib/scad_primitives.py`) for an existing function that already does what
+you're about to write before adding a new one. Duplicated logic is how
+machines drift out of sync silently - see "Porting a new machine" below
+for the same failure mode at the machine-port level.
 
 ## Geometry invariants
 
@@ -16,9 +16,17 @@ These are hard rules, not stylistic preferences - each one maps to a
 confirmed, previously-shipped bug (see `README.md`/`SESSION_LOG.md` at
 the cited section for the full incident).
 
-- **Real machine numbers live in config YAML, never hardcoded in code.**
-  A second machine should mostly be a new YAML file under `config/`, not
-  a code fork. (`README.md` "Usage"/"Multiple machines")
+- **Real machine numbers (dimensions, tolerances, offsets) live in config
+  YAML, never hardcoded in code, no matter which machine.** This does
+  NOT mean a new machine is expected to be config-only, though - that
+  was true for Postal-following-Blickensderfer specifically (they share
+  everything except the drive-pin trio: `README.md` "Multiple
+  machines"), but Mignon diverges from `cylinder_machine.py` "across
+  essentially the whole body-construction half of the pipeline" (its own
+  module docstring) and Bennett needed its own `tune.py` tabs/layouts/
+  field-lists. If the physical geometry genuinely differs, real new lib
+  code is expected and correct - just keep the numeric constants for it
+  in that machine's YAML. See "Porting a new machine" below.
 - **Assembly booleans go through real `manifold3d`
   (`sp.union_all()`/`Manifold.batch_boolean()`), never
   `trimesh.util.concatenate()`.** Concatenate merges overlapping vertex/
@@ -65,12 +73,92 @@ the cited section for the full incident).
 
 ## Porting a new machine
 
+### Machine taxonomy - don't assume "cylindrical" implies "shares code"
+
+- **Physical form and code-sharing are two separate axes - check both,
+  don't infer one from the other.** Ported so far: Blickensderfer,
+  Postal, Mignon, Bennett. Remaining, per the roadmap: Helios Klimax
+  (cylindrical), Hammond/Hammond_split (shuttle mechanism - a different
+  form factor from the cylindrical family), IBM (spherical - also a
+  different form factor). All of Blickensderfer/Postal/Mignon/Bennett/
+  Helios are cylindrical in outward form, but:
+  - **Blickensderfer and Postal are near-twins** - they diverge in code
+    only at the "drive pin trio" (`HollowSpace`/`DrivePin`/
+    `ResinSupport`); everything else lives in `lib/cylinder_machine.py`
+    and is genuinely shared. (`README.md` "Multiple machines")
+  - **Mignon and Bennett are cylindrical in form only** - each diverges
+    from `cylinder_machine.py` across most of the body-construction
+    pipeline (Mignon's own module docstring: "essentially the whole
+    body-construction half"; Bennett needed its own `tune.py` tabs/
+    layouts/field-lists). Being cylindrical did not predict how much
+    they could actually reuse.
+  - Treat Helios the same way Mignon/Bennett were treated - diff its
+    real v2 source against `cylinder_machine.py` function-by-function
+    before assuming reuse, and don't assume it behaves like
+    Blickensderfer/Postal just because it's cylindrical too.
+  - **Hammond/Hammond_split and IBM are a different form factor
+    entirely** - don't reach for `cylinder_machine.py` as the starting
+    point for either; they need their own equivalent of that
+    exercise (identify what, if anything, is genuinely shared with an
+    existing machine vs. `glyph_poc.py`/`scad_primitives.py`-level
+    primitives only).
+  - `lib/cylinder_machine.py`'s own module docstring used to frame it as
+    "Blickensderfer/Postal, and future family members" - that framing was
+    stale (fixed to state the above explicitly) and should stay corrected;
+    don't let it drift back to implying whole-module reuse for a new
+    cylindrical machine.
+
+### Before porting: always diff against the real v2 source
+
+- **The real v2 source (`/home/lchau/github/Type-Elements/v2/<name>.scad`
+  plus its `v2/lib/` includes) is the ground truth for a new machine's
+  geometry and values - config YAML and lib code are ports of it, never
+  invented independently.** Cross-reference specific v2 line numbers in
+  comments/config when a v4 value or behavior corresponds to a v2
+  variable, the way `config/bennett.yaml` and `lib/bennett.py` already
+  do. When v4 intentionally drops or changes something from v2 (a dead
+  customizer param, a resolved-differently default), say so explicitly
+  in a comment instead of silently diverging - `bennett.yaml`'s
+  dead-param callouts are the model to copy.
 - **Don't assume a new machine reuses `lib/cylinder_machine.py` just
   because it looks similar on paper - verify function-by-function
   against the real v2 source first.** Mignon looked like Postal
   (another cylinder machine) but shared almost nothing structurally.
   (`SESSION_LOG.md` part 19; explicit warning for future machines in
   part 22)
+- **`cylinder_machine.place_on_cylinder`'s docstring used to say
+  Mignon/Bennett/Helios all pass a placement radius of 0 - that was
+  already wrong for Bennett** (`lib/bennett.py`'s `configure()` deliberately
+  does NOT pass 0, and explains why at length) **and has been corrected**
+  to say so per-machine instead of asserting it from physical form. If
+  you touch this docstring again, keep it stating the real, verified
+  value per machine (not "Helios probably does X too") - a wrong
+  assumption here is exactly what would make the next port repeat a
+  bug Bennett already had to work around.
+
+### Keep doing this (positive patterns, worth replicating verbatim)
+
+- **Every machine module's entry points use the same names and
+  near-identical signatures**: `configure(config_path)`,
+  `_require_configured()`, `FullElement(...)`, `ResinPrint(...)`,
+  `Additive(...)`, `CalibrationElement(...)`, `CalibrationAdditive(...)`,
+  even accepting-but-ignoring a kwarg a given machine doesn't need
+  (e.g. Mignon's `FullElement` accepts `render_core_groove` purely so
+  `generate.py`'s uniform `build_fn(...)` call works across machines).
+  Keep this consistent for the next machine even when its geometry
+  doesn't need every kwarg.
+- **`generate.py` dispatches via `importlib.import_module(cfg["machine"])`
+  - the module filename must equal the config's `machine:` value.** This
+  convention is load-bearing but not written down anywhere else; a new
+  machine's module and `machine:` key must match exactly.
+- **When two machines share a derivation, extract it into
+  `lib/cylinder_machine.py` as a named function, the way
+  `resin_raft_config()` was extracted for Blickensderfer/Postal's
+  `resin.raft` toggle** - don't leave the same computation hand-copied
+  into two machine modules. (Known still-open case: `Bottom_Slope`/
+  `Bottom_Z_Offset` is currently duplicated byte-for-byte in
+  `lib/blickensderfer.py` and `lib/postal.py` - extract it opportunistically
+  if you're touching either.)
 - **If the new machine has a different row/column count than existing
   ones, grep `tune.py` for hardcoded literal counts (`range(3)`, "3
   rows", etc.) rather than assuming the tab code is already generic.**
@@ -81,6 +169,57 @@ the cited section for the full incident).
   capital-leading names from the source module's globals, plus a
   hardcoded `z` exception.** A new machine-set global with a lowercase
   name is silently excluded - a `NameError` footgun, not a loud failure.
+
+### Pick one convention, don't let it re-fork per machine
+
+- **A config concept that already exists on another machine goes in the
+  same top-level YAML section, every time - don't let it drift to a
+  different section because it "feels like" it belongs elsewhere.**
+  Concrete outlier already in the codebase: the resin facet-count knob
+  is `resin.resin_fn` for Blickensderfer/Postal/Bennett but
+  `quality.resin_fn` for Mignon (with the matching `tune.py` field
+  living on the Resin tab for three machines and the Quality tab for
+  Mignon). Don't add a fifth variant - either match the majority
+  (`resin.resin_fn`) for the next machine, or fix Mignon's placement
+  while you're in the area.
+- **A list-valued config key that doesn't fit `tune.py`'s generic
+  scalar `FIELDS` mechanism needs an explicit decision, made and
+  written down, not a silent gap.** The two legitimate outcomes are (a)
+  a bespoke per-item patcher, like `layout.baseline_row`/`cutout_row`
+  got via `patch_yaml_list_item`, or (b) deliberately YAML-only with a
+  one-line comment saying so, like `layout.placement_map`/
+  `char_legend`. Bennett's `element.alignment_hole_height` (also a
+  3-item list) currently gets neither - it's silently unexposed in the
+  UI with no comment explaining why it didn't get treatment (a). Don't
+  repeat that: any new list-valued key must land in (a) or (b)
+  explicitly.
+- **Reused geometry helpers that are "almost the same" across machines
+  (e.g. the top/bottom Minkowski-cleanup cap, or a shaft-bore stand-in
+  cylinder) should gain a parameter in the shared `cylinder_machine.py`
+  version rather than being hand-copied per machine.** Mignon's and
+  Bennett's `MinkCleanup()`/`CenterShaft()` are each independently
+  reimplemented instead of sharing one parametrized version; Bennett's
+  own `SpeedHoles()` comment already flags it as differing from
+  `cylinder_machine.SpeedHoles()` by only a phase-offset constant.
+  Treat a comment like that as a TODO to resolve during the *next*
+  port that touches the same area, not permanent documentation of an
+  accepted duplicate.
+- **If a new machine's epsilon-style constant (`z` in `configure()`)
+  needs a different magnitude than the existing machines use, say why
+  in a comment.** Blickensderfer/Postal use `0.01`; Mignon/Bennett use
+  `0.001`, with no comment anywhere explaining the change - don't add a
+  third unexplained value.
+
+### Process, not just files
+
+- **Every machine port gets its own dated `SESSION_LOG.md` chapter with
+  an explicit audit pass** - diff the new machine's config/lib/tune.py
+  fields against sibling machines' equivalent fields and against the
+  real v2 source, the way Mignon's port did (parts 19-21), not just a
+  port-and-merge with no dedicated review. Bennett's port has no such
+  chapter, and it correlates with Bennett having more small, undocumented
+  inconsistencies (see "Pick one convention" above) than Mignon does.
+  Don't skip this for Helios/Hammond/IBM even under time pressure.
 
 ## TUI (tune.py)
 
@@ -101,6 +240,18 @@ the cited section for the full incident).
   need their own bespoke patcher (see `patch_yaml_list_item`/the
   block-list patch in `tune.py`), not the generic single-scalar FIELDS
   mechanism.** (`SESSION_LOG.md` parts 17, 20)
+- **Per-machine banner/help text (prose that varies by machine but isn't
+  a per-field tooltip) goes in a dict keyed by machine name, defined
+  once near the other per-machine tables (`LAYOUT_PRESETS_BY_MACHINE`
+  etc.), never as a hand-written `if self.machine == "x": ... elif ...`
+  chain inside a `_compose_*_tab` method.** A new machine should mean
+  adding one dict entry, not growing a branch. `LAYOUT_PICKER_HELP` (used
+  by `_compose_layout_tab`) is the template to copy - it replaced exactly
+  this kind of if/elif chain, which is also where the manual-`\n` bug
+  in the tooltip rule below was found live (Bennett's entry, fixed in
+  the same pass). If you're adding banner text for a new machine and no
+  such dict exists yet for that banner, create one rather than adding
+  a branch to existing code.
 
 ### tooltip/help-text `Static` widgets
 

--- a/v4/lib/cylinder_machine.py
+++ b/v4/lib/cylinder_machine.py
@@ -1,13 +1,24 @@
 """
-Shared cylinder-machine-family code (Blickensderfer/Postal, and future
-family members) - functions here are structurally identical between those
-machines in v2 (same lib/core_shaft.scad, lib/resin_rod.scad,
-lib/resin_support.scad, lib/glyph_pipeline.scad includes), differing only
-in the config-derived parameter VALUES each machine's own configure()
-sets. Machine-specific functions (HollowSpace/DrivePin/ResinSupport - the
-"drive pin trio", the one place v2's two machines genuinely diverge in
-code, not just values) live one-per-machine in lib/blickensderfer.py /
-lib/postal.py instead, and are called from here as ordinary bare names.
+Shared cylinder-machine-family code. Structurally, this module is a full
+shared implementation for exactly Blickensderfer/Postal - functions here
+are structurally identical between those two machines in v2 (same
+lib/core_shaft.scad, lib/resin_rod.scad, lib/resin_support.scad,
+lib/glyph_pipeline.scad includes), differing only in the config-derived
+parameter VALUES each machine's own configure() sets. Machine-specific
+functions (HollowSpace/DrivePin/ResinSupport - the "drive pin trio", the
+one place v2's two machines genuinely diverge in code, not just values)
+live one-per-machine in lib/blickensderfer.py / lib/postal.py instead, and
+are called from here as ordinary bare names.
+
+Other cylindrical machines (Mignon, Bennett, and presumably Helios) are
+NOT full-module reuse cases - each diverges from the rest of this module
+across most of its own body-construction pipeline, and only pulls in
+specific pieces (place_on_cylinder/TextRing/CalibrationTextRing, the
+resin-rod helpers, lib/core_shaft.scad's shared functions). Being
+cylindrical in outward form does not predict how much of this module a
+new machine can actually reuse - verify function-by-function against the
+real v2 source before assuming otherwise (see CLAUDE.md "Porting a new
+machine").
 
 Dynamic dispatch: each machine's configure() calls _receive_config(g,
 name) at the end, which copies every uppercase-leading global (the ~100
@@ -123,10 +134,16 @@ def place_on_cylinder(mesh, row, col, separation_mm, baseline_mm=None,
     Postal add the FULL Char_Protrusion at the placement stage too (their
     raw material genuinely stands proud of the plain element surface
     before any cutout trims it) - None defaults to Char_Protrusion,
-    preserving that. Mignon/Bennett/Helios's placement radius is the raw
-    Element_Diameter/2 instead (embed depth controlled by the glyph's own
-    geometry, not a placement-stage protrusion) - they pass 0. Does NOT
-    affect the platen cutout's own radius formula (still always the full
+    preserving that. Mignon's placement radius is the raw Element_Diameter/2
+    instead (embed depth controlled by the glyph's own geometry, not a
+    placement-stage protrusion) - it passes 0. Bennett does NOT pass 0
+    despite being cylindrical like Mignon - it deliberately keeps the
+    default (Char_Protrusion), because v4's single-transform placement
+    pipeline doesn't behave like v2's two-independent-transforms one; see
+    lib/bennett.py's module docstring and configure() comment for the full
+    derivation. Don't assume a new machine's value from its physical form -
+    verify against its own v2 source (Helios not yet verified either way).
+    Does NOT affect the platen cutout's own radius formula (still always the full
     Char_Protrusion, baked into build_glyph via radius_y_offset_mm,
     unrelated to this override - verified algebraically in v2, see
     PlatenCutout's comment in lib/glyph_pipeline.scad).

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -980,6 +980,35 @@ LAYOUT_PRESETS_BY_MACHINE = {
     "bennett": LAYOUT_PRESETS_BENNETT,
 }
 
+# Layout tab's picker-help banner, one flowing string per machine (see
+# CLAUDE.md's tooltip/help-text rules - no manual \n; add the next
+# machine's entry here instead of an if/elif in _compose_layout_tab).
+LAYOUT_PICKER_HELP = {
+    "blickensderfer": (
+        "All layouts share the same physical placement_map - only glyph "
+        "content per row changes. HEBREW_ENGL needs a Hebrew-capable font "
+        "path; v4 doesn't auto-switch fonts per layout like v2 did."
+    ),
+    "postal": (
+        "Postal has only one physical layout, QWERTY. Use Modify glyphs "
+        "below to hand-edit the rows for anything else."
+    ),
+    "mignon": (
+        "30 named layouts, all sharing the same 7-row/12-column physical "
+        "layout - only glyph content changes per row. Rows are shown in "
+        "keyboard-legend order; char_legend remaps this to build order "
+        "internally."
+    ),
+    "bennett": (
+        "Ported from v2/lib/layouts/bennett_layouts.scad's ENGLISH/BRITISH/"
+        "INTERNATIONAL plus v2/bennett.scad's own CUSTOM (identical to "
+        "ENGLISH by default - edit it via Modify glyphs below). All share "
+        "the same 3-row/28-column layout. Rows are shown in keyboard-legend "
+        "order (as printed on the physical keyboard/manual) - "
+        "layout.char_legend remaps this to build order internally."
+    ),
+}
+
 # layout.baseline_row/cutout_row per-row fields (Element tab - see
 # TuneApp._compose_baseline_cutout_fields). Bespoke, not in
 # self.FIELDS/SECTIONS - these are list ELEMENTS (patch_yaml_list_item),
@@ -1437,33 +1466,8 @@ class TuneApp(App):
                     select = Select(options, value=preset_now if preset_now else Select.NULL,
                                     id="layout-select", allow_blank=True, prompt=prompt)
                     yield select
-                if self.machine == "blickensderfer":
-                    yield Static(
-                        "All layouts share the same physical placement_map - only glyph "
-                        "content per row changes. HEBREW_ENGL needs a Hebrew-capable font "
-                        "path; v4 doesn't auto-switch fonts per layout like v2 did.",
-                        classes="picker-help")
-                elif self.machine == "postal":
-                    yield Static(
-                        "Postal has only one physical layout, QWERTY. Use Modify glyphs "
-                        "below to hand-edit the rows for anything else.",
-                        classes="picker-help")
-                elif self.machine == "mignon":
-                    yield Static(
-                        "30 named layouts, all sharing the same 7-row/12-column physical "
-                        "layout - only glyph content changes per row. Rows are shown in "
-                        "keyboard-legend order; char_legend remaps this to build order "
-                        "internally.",
-                        classes="picker-help")
-                elif self.machine == "bennett":
-                    yield Static(
-                        "Ported from v2/lib/layouts/bennett_layouts.scad's ENGLISH/BRITISH/\n"
-                        "INTERNATIONAL plus v2/bennett.scad's own CUSTOM (identical to\n"
-                        "ENGLISH by default - edit it via Modify glyphs below). All share\n"
-                        "the same 3-row/28-column layout. Rows are shown in keyboard-\n"
-                        "legend order (as printed on the physical keyboard/manual) -\n"
-                        "layout.char_legend remaps this to build order internally.",
-                        classes="picker-help")
+                if self.machine in LAYOUT_PICKER_HELP:
+                    yield Static(LAYOUT_PICKER_HELP[self.machine], classes="picker-help")
                 elif options:
                     yield Static(
                         "Use Modify glyphs below to hand-edit the rows for anything "


### PR DESCRIPTION
## Summary
- Audited the recently-written `v4/CLAUDE.md` against the live code (config YAMLs, `lib/*.py` per machine, `tune.py`) and corrected one overstated rule: "a second machine should mostly be a new YAML file, not a code fork" was only ever true for Postal-following-Blickensderfer — Mignon/Bennett already contradict it (per their own docstrings), so the rule now says numeric constants stay in YAML but new geometry can mean real new code.
- Added a machine taxonomy section: Blickensderfer/Postal are near-twins (share nearly everything via `cylinder_machine.py`), Mignon/Bennett/Helios are cylindrical in form only (each diverges structurally), Hammond/Hammond_split (shuttle) and IBM (spherical) are different form factors entirely — don't assume `cylinder_machine.py` reuse from physical shape alone.
- Added v2-source-of-truth discipline (`v2/<name>.scad` + `v2/lib/` is ground truth for a new port) and folded in the concrete drift found by comparing all four ported machines: duplicated `Bottom_Slope` derivation, `resin_fn`'s inconsistent config section (Mignon puts it under `quality:`, others under `resin:`), the `alignment_hole_height` list-valued-key gap, an unexplained epsilon-constant (`z`) change between machine generations, and the missing per-port `SESSION_LOG.md` audit chapter for Bennett's port.
- Fixed two stale/misleading docstrings the audit surfaced (`lib/cylinder_machine.py`'s module docstring and `place_on_cylinder`'s `placement_protrusion` note) — both asserted things about Mignon/Bennett/Helios that are already false for Bennett, and would have misled the next (Helios) port into repeating a bug Bennett had to explicitly work around.
- Refactored `tune.py`'s one remaining ad-hoc `if self.machine == "x": ... elif ...` banner (the Layout tab's picker-help text) into a `LAYOUT_PICKER_HELP` dict keyed by machine name, matching the existing `LAYOUT_PRESETS_BY_MACHINE` pattern — this also fixed a live instance of the manual-`\n` tooltip bug in Bennett's entry, and gives future ports (Helios/Hammond/IBM) a dict entry to add instead of another branch.

## Test plan
- [x] `python3 -m py_compile tune.py` passes
- [x] Verified `LAYOUT_PICKER_HELP` strings contain no manual `\n`
- [x] Ran `TuneApp` headless (Textual pilot, scratch config copies only, per CLAUDE.md's own rule) for all four machines and confirmed the Layout tab's picker-help `Static` renders with sane auto-computed heights (no crashes, no doubled wrapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)