### PR TITLE
v4: add cross-section debug controls to the Build tab

### DIFF
--- a/v4/CLAUDE.md
+++ b/v4/CLAUDE.md
@@ -4,11 +4,11 @@
 
 Search `lib/cylinder_machine.py` (shared across cylinder machines) and the
 target machine's own module (`lib/blickensderfer.py`, `lib/postal.py`,
-`lib/mignon.py`, `lib/glyph_poc.py`, `lib/scad_primitives.py`) for an
-existing function that already does what you're about to write before
-adding a new one. Duplicated logic is how the two machines drift out of
-sync silently - see "Porting a new machine" below for the same failure
-mode at the machine-port level.
+`lib/mignon.py`, `lib/bennett.py`, `lib/glyph_poc.py`,
+`lib/scad_primitives.py`) for an existing function that already does what
+you're about to write before adding a new one. Duplicated logic is how
+machines drift out of sync silently - see "Porting a new machine" below
+for the same failure mode at the machine-port level.
 
 ## Geometry invariants
 
@@ -16,9 +16,17 @@ These are hard rules, not stylistic preferences - each one maps to a
 confirmed, previously-shipped bug (see `README.md`/`SESSION_LOG.md` at
 the cited section for the full incident).
 
-- **Real machine numbers live in config YAML, never hardcoded in code.**
-  A second machine should mostly be a new YAML file under `config/`, not
-  a code fork. (`README.md` "Usage"/"Multiple machines")
+- **Real machine numbers (dimensions, tolerances, offsets) live in config
+  YAML, never hardcoded in code, no matter which machine.** This does
+  NOT mean a new machine is expected to be config-only, though - that
+  was true for Postal-following-Blickensderfer specifically (they share
+  everything except the drive-pin trio: `README.md` "Multiple
+  machines"), but Mignon diverges from `cylinder_machine.py` "across
+  essentially the whole body-construction half of the pipeline" (its own
+  module docstring) and Bennett needed its own `tune.py` tabs/layouts/
+  field-lists. If the physical geometry genuinely differs, real new lib
+  code is expected and correct - just keep the numeric constants for it
+  in that machine's YAML. See "Porting a new machine" below.
 - **Assembly booleans go through real `manifold3d`
   (`sp.union_all()`/`Manifold.batch_boolean()`), never
   `trimesh.util.concatenate()`.** Concatenate merges overlapping vertex/
@@ -65,12 +73,92 @@ the cited section for the full incident).
 
 ## Porting a new machine
 
+### Machine taxonomy - don't assume "cylindrical" implies "shares code"
+
+- **Physical form and code-sharing are two separate axes - check both,
+  don't infer one from the other.** Ported so far: Blickensderfer,
+  Postal, Mignon, Bennett. Remaining, per the roadmap: Helios Klimax
+  (cylindrical), Hammond/Hammond_split (shuttle mechanism - a different
+  form factor from the cylindrical family), IBM (spherical - also a
+  different form factor). All of Blickensderfer/Postal/Mignon/Bennett/
+  Helios are cylindrical in outward form, but:
+  - **Blickensderfer and Postal are near-twins** - they diverge in code
+    only at the "drive pin trio" (`HollowSpace`/`DrivePin`/
+    `ResinSupport`); everything else lives in `lib/cylinder_machine.py`
+    and is genuinely shared. (`README.md` "Multiple machines")
+  - **Mignon and Bennett are cylindrical in form only** - each diverges
+    from `cylinder_machine.py` across most of the body-construction
+    pipeline (Mignon's own module docstring: "essentially the whole
+    body-construction half"; Bennett needed its own `tune.py` tabs/
+    layouts/field-lists). Being cylindrical did not predict how much
+    they could actually reuse.
+  - Treat Helios the same way Mignon/Bennett were treated - diff its
+    real v2 source against `cylinder_machine.py` function-by-function
+    before assuming reuse, and don't assume it behaves like
+    Blickensderfer/Postal just because it's cylindrical too.
+  - **Hammond/Hammond_split and IBM are a different form factor
+    entirely** - don't reach for `cylinder_machine.py` as the starting
+    point for either; they need their own equivalent of that
+    exercise (identify what, if anything, is genuinely shared with an
+    existing machine vs. `glyph_poc.py`/`scad_primitives.py`-level
+    primitives only).
+  - `lib/cylinder_machine.py`'s own module docstring used to frame it as
+    "Blickensderfer/Postal, and future family members" - that framing was
+    stale (fixed to state the above explicitly) and should stay corrected;
+    don't let it drift back to implying whole-module reuse for a new
+    cylindrical machine.
+
+### Before porting: always diff against the real v2 source
+
+- **The real v2 source (`/home/lchau/github/Type-Elements/v2/<name>.scad`
+  plus its `v2/lib/` includes) is the ground truth for a new machine's
+  geometry and values - config YAML and lib code are ports of it, never
+  invented independently.** Cross-reference specific v2 line numbers in
+  comments/config when a v4 value or behavior corresponds to a v2
+  variable, the way `config/bennett.yaml` and `lib/bennett.py` already
+  do. When v4 intentionally drops or changes something from v2 (a dead
+  customizer param, a resolved-differently default), say so explicitly
+  in a comment instead of silently diverging - `bennett.yaml`'s
+  dead-param callouts are the model to copy.
 - **Don't assume a new machine reuses `lib/cylinder_machine.py` just
   because it looks similar on paper - verify function-by-function
   against the real v2 source first.** Mignon looked like Postal
   (another cylinder machine) but shared almost nothing structurally.
   (`SESSION_LOG.md` part 19; explicit warning for future machines in
   part 22)
+- **`cylinder_machine.place_on_cylinder`'s docstring used to say
+  Mignon/Bennett/Helios all pass a placement radius of 0 - that was
+  already wrong for Bennett** (`lib/bennett.py`'s `configure()` deliberately
+  does NOT pass 0, and explains why at length) **and has been corrected**
+  to say so per-machine instead of asserting it from physical form. If
+  you touch this docstring again, keep it stating the real, verified
+  value per machine (not "Helios probably does X too") - a wrong
+  assumption here is exactly what would make the next port repeat a
+  bug Bennett already had to work around.
+
+### Keep doing this (positive patterns, worth replicating verbatim)
+
+- **Every machine module's entry points use the same names and
+  near-identical signatures**: `configure(config_path)`,
+  `_require_configured()`, `FullElement(...)`, `ResinPrint(...)`,
+  `Additive(...)`, `CalibrationElement(...)`, `CalibrationAdditive(...)`,
+  even accepting-but-ignoring a kwarg a given machine doesn't need
+  (e.g. Mignon's `FullElement` accepts `render_core_groove` purely so
+  `generate.py`'s uniform `build_fn(...)` call works across machines).
+  Keep this consistent for the next machine even when its geometry
+  doesn't need every kwarg.
+- **`generate.py` dispatches via `importlib.import_module(cfg["machine"])`
+  - the module filename must equal the config's `machine:` value.** This
+  convention is load-bearing but not written down anywhere else; a new
+  machine's module and `machine:` key must match exactly.
+- **When two machines share a derivation, extract it into
+  `lib/cylinder_machine.py` as a named function, the way
+  `resin_raft_config()` was extracted for Blickensderfer/Postal's
+  `resin.raft` toggle** - don't leave the same computation hand-copied
+  into two machine modules. (Known still-open case: `Bottom_Slope`/
+  `Bottom_Z_Offset` is currently duplicated byte-for-byte in
+  `lib/blickensderfer.py` and `lib/postal.py` - extract it opportunistically
+  if you're touching either.)
 - **If the new machine has a different row/column count than existing
   ones, grep `tune.py` for hardcoded literal counts (`range(3)`, "3
   rows", etc.) rather than assuming the tab code is already generic.**
@@ -81,6 +169,57 @@ the cited section for the full incident).
   capital-leading names from the source module's globals, plus a
   hardcoded `z` exception.** A new machine-set global with a lowercase
   name is silently excluded - a `NameError` footgun, not a loud failure.
+
+### Pick one convention, don't let it re-fork per machine
+
+- **A config concept that already exists on another machine goes in the
+  same top-level YAML section, every time - don't let it drift to a
+  different section because it "feels like" it belongs elsewhere.**
+  Concrete outlier already in the codebase: the resin facet-count knob
+  is `resin.resin_fn` for Blickensderfer/Postal/Bennett but
+  `quality.resin_fn` for Mignon (with the matching `tune.py` field
+  living on the Resin tab for three machines and the Quality tab for
+  Mignon). Don't add a fifth variant - either match the majority
+  (`resin.resin_fn`) for the next machine, or fix Mignon's placement
+  while you're in the area.
+- **A list-valued config key that doesn't fit `tune.py`'s generic
+  scalar `FIELDS` mechanism needs an explicit decision, made and
+  written down, not a silent gap.** The two legitimate outcomes are (a)
+  a bespoke per-item patcher, like `layout.baseline_row`/`cutout_row`
+  got via `patch_yaml_list_item`, or (b) deliberately YAML-only with a
+  one-line comment saying so, like `layout.placement_map`/
+  `char_legend`. Bennett's `element.alignment_hole_height` (also a
+  3-item list) currently gets neither - it's silently unexposed in the
+  UI with no comment explaining why it didn't get treatment (a). Don't
+  repeat that: any new list-valued key must land in (a) or (b)
+  explicitly.
+- **Reused geometry helpers that are "almost the same" across machines
+  (e.g. the top/bottom Minkowski-cleanup cap, or a shaft-bore stand-in
+  cylinder) should gain a parameter in the shared `cylinder_machine.py`
+  version rather than being hand-copied per machine.** Mignon's and
+  Bennett's `MinkCleanup()`/`CenterShaft()` are each independently
+  reimplemented instead of sharing one parametrized version; Bennett's
+  own `SpeedHoles()` comment already flags it as differing from
+  `cylinder_machine.SpeedHoles()` by only a phase-offset constant.
+  Treat a comment like that as a TODO to resolve during the *next*
+  port that touches the same area, not permanent documentation of an
+  accepted duplicate.
+- **If a new machine's epsilon-style constant (`z` in `configure()`)
+  needs a different magnitude than the existing machines use, say why
+  in a comment.** Blickensderfer/Postal use `0.01`; Mignon/Bennett use
+  `0.001`, with no comment anywhere explaining the change - don't add a
+  third unexplained value.
+
+### Process, not just files
+
+- **Every machine port gets its own dated `SESSION_LOG.md` chapter with
+  an explicit audit pass** - diff the new machine's config/lib/tune.py
+  fields against sibling machines' equivalent fields and against the
+  real v2 source, the way Mignon's port did (parts 19-21), not just a
+  port-and-merge with no dedicated review. Bennett's port has no such
+  chapter, and it correlates with Bennett having more small, undocumented
+  inconsistencies (see "Pick one convention" above) than Mignon does.
+  Don't skip this for Helios/Hammond/IBM even under time pressure.
 
 ## TUI (tune.py)
 
@@ -101,6 +240,18 @@ the cited section for the full incident).
   need their own bespoke patcher (see `patch_yaml_list_item`/the
   block-list patch in `tune.py`), not the generic single-scalar FIELDS
   mechanism.** (`SESSION_LOG.md` parts 17, 20)
+- **Per-machine banner/help text (prose that varies by machine but isn't
+  a per-field tooltip) goes in a dict keyed by machine name, defined
+  once near the other per-machine tables (`LAYOUT_PRESETS_BY_MACHINE`
+  etc.), never as a hand-written `if self.machine == "x": ... elif ...`
+  chain inside a `_compose_*_tab` method.** A new machine should mean
+  adding one dict entry, not growing a branch. `LAYOUT_PICKER_HELP` (used
+  by `_compose_layout_tab`) is the template to copy - it replaced exactly
+  this kind of if/elif chain, which is also where the manual-`\n` bug
+  in the tooltip rule below was found live (Bennett's entry, fixed in
+  the same pass). If you're adding banner text for a new machine and no
+  such dict exists yet for that banner, create one rather than adding
+  a branch to existing code.
 
 ### tooltip/help-text `Static` widgets
 

--- a/v4/generate.py
+++ b/v4/generate.py
@@ -11,12 +11,48 @@ config/blickensderfer.yaml for the full parameter set and comments.
 
 import argparse
 import importlib
+import math
 import os
 import sys
 
+import numpy as np
+import trimesh
 import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+
+def _apply_cross_section(mesh, angle_deg, flip):
+    """Debug-only: clips mesh to one side of a vertical plane through the
+    machine's central (Z) axis at angle_deg (degrees, measured in the XY
+    plane) - a cutaway view for inspecting internal geometry (hollow
+    space, drive pin, resin supports, ...) without printing/viewing the
+    whole opaque part. angle_deg=None (the default, nothing passed on the
+    CLI) is a no-op - this never changes output for a normal build.
+    flip=True keeps the opposite half (whichever side would otherwise be
+    discarded) instead.
+
+    Uses manifold3d's own Manifold.trim_by_plane rather than
+    trimesh.intersections.slice_mesh_plane - tried that first, but its
+    triangulated cap left FullElement (no resin supports) non-watertight/
+    non-volume after the cut even off-axis, while manifold3d's native
+    half-space trim (the same engine scad_primitives.union_all() already
+    uses for real assembly booleans, per CLAUDE.md) produced a clean
+    watertight result in the same case."""
+    if angle_deg is None:
+        return mesh
+    from manifold3d import Manifold, Mesh as ManifoldMesh
+
+    angle_rad = math.radians(angle_deg)
+    normal = (math.cos(angle_rad), math.sin(angle_rad), 0.0)
+    if flip:
+        normal = tuple(-n for n in normal)
+    manifold = Manifold(mesh=ManifoldMesh(
+        vert_properties=np.array(mesh.vertices, dtype=np.float32),
+        tri_verts=np.array(mesh.faces, dtype=np.uint32)))
+    trimmed = manifold.trim_by_plane(normal, 0.0)
+    result = trimmed.to_mesh()
+    return trimesh.Trimesh(vertices=result.vert_properties, faces=result.tri_verts, process=False)
 
 
 def _load_machine(config_path):
@@ -109,6 +145,14 @@ def main():
     parser.add_argument("--out", default=None,
                          help="override output.directory/output.stl_name from the config "
                               "(full path to the .stl to write)")
+    parser.add_argument("--cross-section-angle-deg", type=float, default=None,
+                         help="debug: clip the final mesh to one side of a vertical plane "
+                              "through the machine's central axis at this angle (degrees) - "
+                              "applies to any build target (element/gauge/calibration); "
+                              "omit to disable (default)")
+    parser.add_argument("--cross-section-flip", action="store_true",
+                         help="debug: with --cross-section-angle-deg, keep the opposite "
+                              "half of the cut instead of the default side")
     args = parser.parse_args()
 
     bd = _load_machine(args.config)
@@ -133,6 +177,7 @@ def main():
         # not part of the real element at all - no char placement, no
         # HollowSpace intersection check (nothing to check it against)
         full = bd.GaugeTestSet(render_core_groove=render_core_groove)
+        full = _apply_cross_section(full, args.cross_section_angle_deg, args.cross_section_flip)
         print(f"GaugeTestSet: verts={len(full.vertices)} faces={len(full.faces)} "
               f"watertight={full.is_watertight} winding_consistent={full.is_winding_consistent} "
               f"is_volume={full.is_volume} volume={full.volume:.3f}mm3", flush=True)
@@ -171,6 +216,7 @@ def main():
             minkowski_enabled=args.minkowski_enabled,
             draft_angle_deg=args.draft_angle_deg,
         )
+        full = _apply_cross_section(full, args.cross_section_angle_deg, args.cross_section_flip)
         print(f"CalibrationElement: verts={len(full.vertices)} faces={len(full.faces)} "
               f"watertight={full.is_watertight} winding_consistent={full.is_winding_consistent} "
               f"is_volume={full.is_volume} volume={full.volume:.3f}mm3", flush=True)
@@ -198,6 +244,7 @@ def main():
         minkowski_enabled=args.minkowski_enabled,
         draft_angle_deg=args.draft_angle_deg,
     )
+    full = _apply_cross_section(full, args.cross_section_angle_deg, args.cross_section_flip)
 
     label = "ResinPrint" if resin_support else "FullElement"
     print(f"{label}: verts={len(full.vertices)} faces={len(full.faces)} "

--- a/v4/generate.py
+++ b/v4/generate.py
@@ -22,15 +22,13 @@ import yaml
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 
 
-def _apply_cross_section(mesh, angle_deg, flip):
+def _apply_cross_section(mesh, angle_deg):
     """Debug-only: clips mesh to one side of a vertical plane through the
     machine's central (Z) axis at angle_deg (degrees, measured in the XY
     plane) - a cutaway view for inspecting internal geometry (hollow
     space, drive pin, resin supports, ...) without printing/viewing the
     whole opaque part. angle_deg=None (the default, nothing passed on the
     CLI) is a no-op - this never changes output for a normal build.
-    flip=True keeps the opposite half (whichever side would otherwise be
-    discarded) instead.
 
     Uses manifold3d's own Manifold.trim_by_plane rather than
     trimesh.intersections.slice_mesh_plane - tried that first, but its
@@ -45,8 +43,6 @@ def _apply_cross_section(mesh, angle_deg, flip):
 
     angle_rad = math.radians(angle_deg)
     normal = (math.cos(angle_rad), math.sin(angle_rad), 0.0)
-    if flip:
-        normal = tuple(-n for n in normal)
     manifold = Manifold(mesh=ManifoldMesh(
         vert_properties=np.array(mesh.vertices, dtype=np.float32),
         tri_verts=np.array(mesh.faces, dtype=np.uint32)))
@@ -150,9 +146,13 @@ def main():
                               "through the machine's central axis at this angle (degrees) - "
                               "applies to any build target (element/gauge/calibration); "
                               "omit to disable (default)")
-    parser.add_argument("--cross-section-flip", action="store_true",
-                         help="debug: with --cross-section-angle-deg, keep the opposite "
-                              "half of the cut instead of the default side")
+    parser.add_argument("--cut-bodies", action="store_true",
+                         help="debug: export the union of Subtractive()'s negative/cutter "
+                              "tool bodies (HollowSpace, DrivePin, core grooves, ...) "
+                              "instead of doing the real additive-subtractive difference - "
+                              "lets you verify what's actually about to be removed. Only "
+                              "applies to the plain Element/Resin build path (ignored with "
+                              "--gauge/--calibrate); composes with --cross-section-angle-deg")
     args = parser.parse_args()
 
     bd = _load_machine(args.config)
@@ -177,7 +177,7 @@ def main():
         # not part of the real element at all - no char placement, no
         # HollowSpace intersection check (nothing to check it against)
         full = bd.GaugeTestSet(render_core_groove=render_core_groove)
-        full = _apply_cross_section(full, args.cross_section_angle_deg, args.cross_section_flip)
+        full = _apply_cross_section(full, args.cross_section_angle_deg)
         print(f"GaugeTestSet: verts={len(full.vertices)} faces={len(full.faces)} "
               f"watertight={full.is_watertight} winding_consistent={full.is_winding_consistent} "
               f"is_volume={full.is_volume} volume={full.volume:.3f}mm3", flush=True)
@@ -216,7 +216,7 @@ def main():
             minkowski_enabled=args.minkowski_enabled,
             draft_angle_deg=args.draft_angle_deg,
         )
-        full = _apply_cross_section(full, args.cross_section_angle_deg, args.cross_section_flip)
+        full = _apply_cross_section(full, args.cross_section_angle_deg)
         print(f"CalibrationElement: verts={len(full.vertices)} faces={len(full.faces)} "
               f"watertight={full.is_watertight} winding_consistent={full.is_winding_consistent} "
               f"is_volume={full.is_volume} volume={full.volume:.3f}mm3", flush=True)
@@ -231,22 +231,30 @@ def main():
         print(f"wrote {mapping_path}", flush=True)
         return
 
-    resin_support = args.resin_support if args.resin_support is not None else bd.DEFAULT_RESIN_SUPPORT
+    if args.cut_bodies:
+        # Subtractive() alone is fully independent of Additive()/TextRing
+        # character placement (see cylinder_machine.Subtractive() and its
+        # per-machine equivalents in mignon.py/bennett.py) - skipping the
+        # glyph pipeline entirely also makes this debug view fast.
+        full = bd.Subtractive(render_core_groove)
+        char_parts = []
+        label = "Subtractive (cut bodies)"
+    else:
+        resin_support = args.resin_support if args.resin_support is not None else bd.DEFAULT_RESIN_SUPPORT
+        build_fn = bd.ResinPrint if resin_support else bd.FullElement
+        full, char_parts = build_fn(
+            points_per_mm=args.points_per_mm,
+            separation_mm=args.separation_mm,
+            render_core_groove=render_core_groove,
+            cone_segments=args.cone_segments,
+            simplify_tolerance_mm=args.simplify_tolerance_mm,
+            platen_fn=args.platen_fn,
+            minkowski_enabled=args.minkowski_enabled,
+            draft_angle_deg=args.draft_angle_deg,
+        )
+        label = "ResinPrint" if resin_support else "FullElement"
+    full = _apply_cross_section(full, args.cross_section_angle_deg)
 
-    build_fn = bd.ResinPrint if resin_support else bd.FullElement
-    full, char_parts = build_fn(
-        points_per_mm=args.points_per_mm,
-        separation_mm=args.separation_mm,
-        render_core_groove=render_core_groove,
-        cone_segments=args.cone_segments,
-        simplify_tolerance_mm=args.simplify_tolerance_mm,
-        platen_fn=args.platen_fn,
-        minkowski_enabled=args.minkowski_enabled,
-        draft_angle_deg=args.draft_angle_deg,
-    )
-    full = _apply_cross_section(full, args.cross_section_angle_deg, args.cross_section_flip)
-
-    label = "ResinPrint" if resin_support else "FullElement"
     print(f"{label}: verts={len(full.vertices)} faces={len(full.faces)} "
           f"watertight={full.is_watertight} winding_consistent={full.is_winding_consistent} "
           f"is_volume={full.is_volume} volume={full.volume:.3f}mm3", flush=True)
@@ -260,8 +268,9 @@ def main():
     # HollowBody(), is a structurally different, much simpler taper with
     # no equivalent "does a character reach too far in" diagnostic
     # question), so this check is skipped rather than forced for machines
-    # that don't define it.
-    if hasattr(bd, "HollowSpace"):
+    # that don't define it. Also skipped for --cut-bodies - char_parts is
+    # empty there (no character placement happened at all).
+    if not args.cut_bodies and hasattr(bd, "HollowSpace"):
         hollow = bd.HollowSpace()
         any_hit = any(hollow.contains(part.vertices).any() for part in char_parts)
         print(f"any character root vertex falls inside HollowSpace: {any_hit}", flush=True)

--- a/v4/lib/bennett.py
+++ b/v4/lib/bennett.py
@@ -528,6 +528,11 @@ def _subtractive_parts(render_core_groove):
     return parts
 
 
+def Subtractive(render_core_groove=None):
+    render_core_groove = DEFAULT_RENDER_CORE_GROOVE if render_core_groove is None else render_core_groove
+    return sp.union_all(_subtractive_parts(render_core_groove))
+
+
 def FullElement(points_per_mm=None, separation_mm=None, render_core_groove=None, align_kwargs=None,
                  cone_segments=None, simplify_tolerance_mm=None, platen_fn=None, minkowski_enabled=None,
                  draft_angle_deg=None):
@@ -540,7 +545,7 @@ def FullElement(points_per_mm=None, separation_mm=None, render_core_groove=None,
                                      draft_angle_deg=draft_angle_deg)
     print(f"Additive: verts={len(additive.vertices)} faces={len(additive.faces)} "
           f"watertight={additive.is_watertight}", flush=True)
-    subtractive = sp.union_all(_subtractive_parts(render_core_groove))
+    subtractive = Subtractive(render_core_groove)
     print(f"Subtractive (unioned): verts={len(subtractive.vertices)} faces={len(subtractive.faces)} "
           f"watertight={subtractive.is_watertight}", flush=True)
     full = additive.difference(subtractive, engine="manifold")
@@ -580,7 +585,7 @@ def CalibrationElement(test_char=None, vary_baseline=None, vary_cutout=None, sta
         minkowski_enabled=minkowski_enabled, draft_angle_deg=draft_angle_deg)
     print(f"CalibrationAdditive: verts={len(additive.vertices)} faces={len(additive.faces)} "
           f"watertight={additive.is_watertight}", flush=True)
-    subtractive = sp.union_all(_subtractive_parts(render_core_groove))
+    subtractive = Subtractive(render_core_groove)
     print(f"Subtractive (unioned): verts={len(subtractive.vertices)} faces={len(subtractive.faces)} "
           f"watertight={subtractive.is_watertight}", flush=True)
     full = additive.difference(subtractive, engine="manifold")

--- a/v4/lib/blickensderfer.py
+++ b/v4/lib/blickensderfer.py
@@ -32,7 +32,7 @@ from glyph_poc import (
 )
 import scad_primitives as sp
 import cylinder_machine
-from cylinder_machine import FullElement, ResinPrint, GaugeTestSet, CalibrationElement  # re-exported for callers
+from cylinder_machine import FullElement, ResinPrint, GaugeTestSet, CalibrationElement, Subtractive  # re-exported for callers
 
 _configured = False
 

--- a/v4/lib/cylinder_machine.py
+++ b/v4/lib/cylinder_machine.py
@@ -1,13 +1,24 @@
 """
-Shared cylinder-machine-family code (Blickensderfer/Postal, and future
-family members) - functions here are structurally identical between those
-machines in v2 (same lib/core_shaft.scad, lib/resin_rod.scad,
-lib/resin_support.scad, lib/glyph_pipeline.scad includes), differing only
-in the config-derived parameter VALUES each machine's own configure()
-sets. Machine-specific functions (HollowSpace/DrivePin/ResinSupport - the
-"drive pin trio", the one place v2's two machines genuinely diverge in
-code, not just values) live one-per-machine in lib/blickensderfer.py /
-lib/postal.py instead, and are called from here as ordinary bare names.
+Shared cylinder-machine-family code. Structurally, this module is a full
+shared implementation for exactly Blickensderfer/Postal - functions here
+are structurally identical between those two machines in v2 (same
+lib/core_shaft.scad, lib/resin_rod.scad, lib/resin_support.scad,
+lib/glyph_pipeline.scad includes), differing only in the config-derived
+parameter VALUES each machine's own configure() sets. Machine-specific
+functions (HollowSpace/DrivePin/ResinSupport - the "drive pin trio", the
+one place v2's two machines genuinely diverge in code, not just values)
+live one-per-machine in lib/blickensderfer.py / lib/postal.py instead, and
+are called from here as ordinary bare names.
+
+Other cylindrical machines (Mignon, Bennett, and presumably Helios) are
+NOT full-module reuse cases - each diverges from the rest of this module
+across most of its own body-construction pipeline, and only pulls in
+specific pieces (place_on_cylinder/TextRing/CalibrationTextRing, the
+resin-rod helpers, lib/core_shaft.scad's shared functions). Being
+cylindrical in outward form does not predict how much of this module a
+new machine can actually reuse - verify function-by-function against the
+real v2 source before assuming otherwise (see CLAUDE.md "Porting a new
+machine").
 
 Dynamic dispatch: each machine's configure() calls _receive_config(g,
 name) at the end, which copies every uppercase-leading global (the ~100
@@ -123,10 +134,16 @@ def place_on_cylinder(mesh, row, col, separation_mm, baseline_mm=None,
     Postal add the FULL Char_Protrusion at the placement stage too (their
     raw material genuinely stands proud of the plain element surface
     before any cutout trims it) - None defaults to Char_Protrusion,
-    preserving that. Mignon/Bennett/Helios's placement radius is the raw
-    Element_Diameter/2 instead (embed depth controlled by the glyph's own
-    geometry, not a placement-stage protrusion) - they pass 0. Does NOT
-    affect the platen cutout's own radius formula (still always the full
+    preserving that. Mignon's placement radius is the raw Element_Diameter/2
+    instead (embed depth controlled by the glyph's own geometry, not a
+    placement-stage protrusion) - it passes 0. Bennett does NOT pass 0
+    despite being cylindrical like Mignon - it deliberately keeps the
+    default (Char_Protrusion), because v4's single-transform placement
+    pipeline doesn't behave like v2's two-independent-transforms one; see
+    lib/bennett.py's module docstring and configure() comment for the full
+    derivation. Don't assume a new machine's value from its physical form -
+    verify against its own v2 source (Helios not yet verified either way).
+    Does NOT affect the platen cutout's own radius formula (still always the full
     Char_Protrusion, baked into build_glyph via radius_y_offset_mm,
     unrelated to this override - verified algebraically in v2, see
     PlatenCutout's comment in lib/glyph_pipeline.scad).

--- a/v4/lib/mignon.py
+++ b/v4/lib/mignon.py
@@ -438,12 +438,17 @@ def Additive(points_per_mm=None, separation_mm=None, align_kwargs=None, cone_seg
     return sp.union_all([cleaned, ElementChamfer(), ElementLogo(), ElementLabel()]), char_parts
 
 
+def Subtractive(render_core_groove=None):
+    # render_core_groove: accepted (matching cylinder_machine.Subtractive's
+    # signature/generate.py's uniform build_fn(...) call) but unused -
+    # Mignon has no core grooves at all (no core_shaft.scad family, see
+    # the module docstring).
+    return sp.union_all([CenterShaft(), HollowBody(), AlignmentPin()])
+
+
 def FullElement(points_per_mm=None, separation_mm=None, render_core_groove=None, align_kwargs=None,
                  cone_segments=None, simplify_tolerance_mm=None, platen_fn=None, minkowski_enabled=None,
                  draft_angle_deg=None):
-    # render_core_groove: accepted (matching generate.py's uniform
-    # build_fn(...) call signature) but unused - Mignon has no core
-    # grooves at all (no core_shaft.scad family, see the module docstring)
     _require_configured()
     additive, char_parts = Additive(points_per_mm, separation_mm, align_kwargs=align_kwargs,
                                      cone_segments=cone_segments,
@@ -452,7 +457,7 @@ def FullElement(points_per_mm=None, separation_mm=None, render_core_groove=None,
                                      draft_angle_deg=draft_angle_deg)
     print(f"Additive: verts={len(additive.vertices)} faces={len(additive.faces)} "
           f"watertight={additive.is_watertight}", flush=True)
-    subtractive = sp.union_all([CenterShaft(), HollowBody(), AlignmentPin()])
+    subtractive = Subtractive(render_core_groove)
     print(f"Subtractive (unioned): verts={len(subtractive.vertices)} faces={len(subtractive.faces)} "
           f"watertight={subtractive.is_watertight}", flush=True)
     full = additive.difference(subtractive, engine="manifold")
@@ -506,7 +511,7 @@ def CalibrationElement(test_char=None, vary_baseline=None, vary_cutout=None, sta
         minkowski_enabled=minkowski_enabled, draft_angle_deg=draft_angle_deg)
     print(f"CalibrationAdditive: verts={len(additive.vertices)} faces={len(additive.faces)} "
           f"watertight={additive.is_watertight}", flush=True)
-    subtractive = sp.union_all([CenterShaft(), HollowBody(), AlignmentPin()])
+    subtractive = Subtractive(render_core_groove)
     print(f"Subtractive (unioned): verts={len(subtractive.vertices)} faces={len(subtractive.faces)} "
           f"watertight={subtractive.is_watertight}", flush=True)
     full = additive.difference(subtractive, engine="manifold")

--- a/v4/lib/postal.py
+++ b/v4/lib/postal.py
@@ -28,7 +28,7 @@ from glyph_poc import (
 )
 import scad_primitives as sp
 import cylinder_machine
-from cylinder_machine import FullElement, ResinPrint, GaugeTestSet, CalibrationElement  # re-exported for callers
+from cylinder_machine import FullElement, ResinPrint, GaugeTestSet, CalibrationElement, Subtractive  # re-exported for callers
 
 _configured = False
 

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -980,6 +980,35 @@ LAYOUT_PRESETS_BY_MACHINE = {
     "bennett": LAYOUT_PRESETS_BENNETT,
 }
 
+# Layout tab's picker-help banner, one flowing string per machine (see
+# CLAUDE.md's tooltip/help-text rules - no manual \n; add the next
+# machine's entry here instead of an if/elif in _compose_layout_tab).
+LAYOUT_PICKER_HELP = {
+    "blickensderfer": (
+        "All layouts share the same physical placement_map - only glyph "
+        "content per row changes. HEBREW_ENGL needs a Hebrew-capable font "
+        "path; v4 doesn't auto-switch fonts per layout like v2 did."
+    ),
+    "postal": (
+        "Postal has only one physical layout, QWERTY. Use Modify glyphs "
+        "below to hand-edit the rows for anything else."
+    ),
+    "mignon": (
+        "30 named layouts, all sharing the same 7-row/12-column physical "
+        "layout - only glyph content changes per row. Rows are shown in "
+        "keyboard-legend order; char_legend remaps this to build order "
+        "internally."
+    ),
+    "bennett": (
+        "Ported from v2/lib/layouts/bennett_layouts.scad's ENGLISH/BRITISH/"
+        "INTERNATIONAL plus v2/bennett.scad's own CUSTOM (identical to "
+        "ENGLISH by default - edit it via Modify glyphs below). All share "
+        "the same 3-row/28-column layout. Rows are shown in keyboard-legend "
+        "order (as printed on the physical keyboard/manual) - "
+        "layout.char_legend remaps this to build order internally."
+    ),
+}
+
 # layout.baseline_row/cutout_row per-row fields (Element tab - see
 # TuneApp._compose_baseline_cutout_fields). Bespoke, not in
 # self.FIELDS/SECTIONS - these are list ELEMENTS (patch_yaml_list_item),
@@ -1437,33 +1466,8 @@ class TuneApp(App):
                     select = Select(options, value=preset_now if preset_now else Select.NULL,
                                     id="layout-select", allow_blank=True, prompt=prompt)
                     yield select
-                if self.machine == "blickensderfer":
-                    yield Static(
-                        "All layouts share the same physical placement_map - only glyph "
-                        "content per row changes. HEBREW_ENGL needs a Hebrew-capable font "
-                        "path; v4 doesn't auto-switch fonts per layout like v2 did.",
-                        classes="picker-help")
-                elif self.machine == "postal":
-                    yield Static(
-                        "Postal has only one physical layout, QWERTY. Use Modify glyphs "
-                        "below to hand-edit the rows for anything else.",
-                        classes="picker-help")
-                elif self.machine == "mignon":
-                    yield Static(
-                        "30 named layouts, all sharing the same 7-row/12-column physical "
-                        "layout - only glyph content changes per row. Rows are shown in "
-                        "keyboard-legend order; char_legend remaps this to build order "
-                        "internally.",
-                        classes="picker-help")
-                elif self.machine == "bennett":
-                    yield Static(
-                        "Ported from v2/lib/layouts/bennett_layouts.scad's ENGLISH/BRITISH/\n"
-                        "INTERNATIONAL plus v2/bennett.scad's own CUSTOM (identical to\n"
-                        "ENGLISH by default - edit it via Modify glyphs below). All share\n"
-                        "the same 3-row/28-column layout. Rows are shown in keyboard-\n"
-                        "legend order (as printed on the physical keyboard/manual) -\n"
-                        "layout.char_legend remaps this to build order internally.",
-                        classes="picker-help")
+                if self.machine in LAYOUT_PICKER_HELP:
+                    yield Static(LAYOUT_PICKER_HELP[self.machine], classes="picker-help")
                 elif options:
                     yield Static(
                         "Use Modify glyphs below to hand-edit the rows for anything "

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -1539,6 +1539,29 @@ class TuneApp(App):
                     "(see the Calibration tab) to find layout.baseline_row/cutout_row.",
                     classes="picker-help")
 
+                yield Static("Debug", classes="field-label")
+                with Horizontal(classes="picker-row"):
+                    yield Static("Cross section", classes="field-label")
+                    yield Switch(value=False, id="build-xsection-enabled")
+                with Vertical(classes="field-row"):
+                    with Horizontal():
+                        yield Static("Angle of plane (deg)", classes="field-label")
+                        yield Input(value="0", id="build-xsection-angle")
+                    yield Static(
+                        "Only applies while Cross section is on. Clips the built "
+                        "mesh to one side of a vertical plane through the machine's "
+                        "central axis at this angle.",
+                        classes="field-help")
+                with Horizontal(classes="picker-row"):
+                    yield Static("Render only the cut bodies", classes="field-label")
+                    yield Switch(value=False, id="build-xsection-flip")
+                yield Static(
+                    "Keeps the opposite half of the cut instead of the default "
+                    "side - i.e. whichever half is normally removed. Session-only "
+                    "debug settings: not saved to the config, apply to any build "
+                    "target (Element/Shaft Gauge/Calibration Element).",
+                    classes="picker-help")
+
     def _compose_type_test_tab(self):
         with TabPane("Type Test", id="tab-type-test"):
             with VerticalScroll():
@@ -1862,6 +1885,20 @@ class TuneApp(App):
         label = "Quick Preview" if fast else "Render"
         self.log_line(f"[bold]--- {label} ---[/bold]")
         cmd = [sys.executable, os.path.join(REPO_ROOT, "generate.py"), self.config_path]
+        # Debug section's cross-section controls - session-only (never
+        # saved to the config, see _compose_build_tab), so read straight
+        # from the widgets here rather than through values/_collect_values.
+        # Applies to any build target below, hence handled once up front.
+        if self.query_one("#build-xsection-enabled", Switch).value:
+            angle_raw = self.query_one("#build-xsection-angle", Input).value.strip()
+            try:
+                angle = float(angle_raw)
+            except ValueError:
+                self.log_line(f"[red]bad cross-section angle: {angle_raw!r} (expected a number)[/red]")
+                return
+            cmd += ["--cross-section-angle-deg", str(angle)]
+            if self.query_one("#build-xsection-flip", Switch).value:
+                cmd += ["--cross-section-flip"]
         if values["target"] == "gauge":
             # GaugeTestSet() doesn't touch TextRing/build_glyph at all, so
             # the Minkowski/points-per-mm knobs don't apply here.

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -1554,12 +1554,14 @@ class TuneApp(App):
                         classes="field-help")
                 with Horizontal(classes="picker-row"):
                     yield Static("Render only the cut bodies", classes="field-label")
-                    yield Switch(value=False, id="build-xsection-flip")
+                    yield Switch(value=False, id="build-cut-bodies")
                 yield Static(
-                    "Keeps the opposite half of the cut instead of the default "
-                    "side - i.e. whichever half is normally removed. Session-only "
-                    "debug settings: not saved to the config, apply to any build "
-                    "target (Element/Shaft Gauge/Calibration Element).",
+                    "Exports the negative/cutter tool bodies (HollowSpace, drive "
+                    "pin, core grooves, ...) instead of the real element, so you "
+                    "can verify what's actually being removed - independent of "
+                    "Cross section, and only applies to Element/Resin builds "
+                    "(ignored for Shaft Gauge/Calibration Element). Session-only "
+                    "debug settings: neither of these is saved to the config.",
                     classes="picker-help")
 
     def _compose_type_test_tab(self):
@@ -1885,10 +1887,12 @@ class TuneApp(App):
         label = "Quick Preview" if fast else "Render"
         self.log_line(f"[bold]--- {label} ---[/bold]")
         cmd = [sys.executable, os.path.join(REPO_ROOT, "generate.py"), self.config_path]
-        # Debug section's cross-section controls - session-only (never
-        # saved to the config, see _compose_build_tab), so read straight
-        # from the widgets here rather than through values/_collect_values.
-        # Applies to any build target below, hence handled once up front.
+        # Debug section's controls - session-only (never saved to the
+        # config, see _compose_build_tab), so read straight from the
+        # widgets here rather than through values/_collect_values. Both
+        # are independent of each other and of the build target below -
+        # --cut-bodies is simply ignored by generate.py for the gauge/
+        # calibrate branches (see its own docstring).
         if self.query_one("#build-xsection-enabled", Switch).value:
             angle_raw = self.query_one("#build-xsection-angle", Input).value.strip()
             try:
@@ -1897,8 +1901,8 @@ class TuneApp(App):
                 self.log_line(f"[red]bad cross-section angle: {angle_raw!r} (expected a number)[/red]")
                 return
             cmd += ["--cross-section-angle-deg", str(angle)]
-            if self.query_one("#build-xsection-flip", Switch).value:
-                cmd += ["--cross-section-flip"]
+        if self.query_one("#build-cut-bodies", Switch).value:
+            cmd += ["--cut-bodies"]
         if values["target"] == "gauge":
             # GaugeTestSet() doesn't touch TextRing/build_glyph at all, so
             # the Minkowski/points-per-mm knobs don't apply here.


### PR DESCRIPTION
## Summary
- New **Debug** section in the Build tab: a "Cross section" checkbox, an "Angle of plane (deg)" input, and a "Render only the cut bodies" checkbox - independent of each other and composable.
- Session-only, not saved to the config (per request - this is a global debug toggle, not a per-machine value) - read directly from the widgets and passed to `generate.py` as CLI flags.
- **Cross section**: clips the built mesh to one side of a vertical plane through the machine's central (Z) axis at the given angle - a cutaway view. Applies to any build target.
- **Render only the cut bodies**: exports the union of `Subtractive()`'s negative/cutter tool bodies (HollowSpace, drive pin, core grooves, ...) instead of doing the real additive-subtractive difference - lets you verify what's actually about to be removed before trusting the final part. Only meaningful for the plain Element/Resin build path (harmlessly ignored for Shaft Gauge/Calibration Element).

Both controls compose: cross-sectioning the cut-bodies view is useful when the tool bodies overlap in ways that are hard to see from outside.

## Implementation notes
- **Cross section**: tried `trimesh.intersections.slice_mesh_plane` first - its triangulated cap left a resin-support-free `FullElement` non-watertight/non-volume after the cut, even off-axis. Switched to `manifold3d`'s own `Manifold.trim_by_plane` (the same boolean engine `scad_primitives.union_all()` already uses for real assembly booleans) - produced a clean watertight result in every case tested.
- **Cut bodies**: `lib/cylinder_machine.py` already exposed a reusable `Subtractive(render_core_groove=None)` (used by Blickensderfer/Postal); `lib/mignon.py` and `lib/bennett.py` each inlined the same `sp.union_all([...])` call twice (FullElement + CalibrationElement) instead. Normalized all four machines to the same `Subtractive()` entry point - this also de-duplicates the two inline call sites in Mignon/Bennett into one function each, and re-exports it from `blickensderfer.py`/`postal.py` alongside `FullElement`/`ResinPrint`/etc. `Subtractive()` doesn't depend on `Additive()`/character placement at all, so this debug view also skips the (slower) glyph pipeline entirely.

**Note:** this branch stacks on `worktree-claude-md-audit` (#30) - both include an earlier `tune.py` refactor from that PR (the `LAYOUT_PICKER_HELP` dict). Rebasing onto `main` after #30 merges will drop that overlap from this diff.

## Test plan
- [x] `python3 -m py_compile` on all touched files
- [x] CLI: ran `generate.py` for all four machines with `--cut-bodies` alone and combined with `--cross-section-angle-deg` - all report `watertight=True winding_consistent=True is_volume=True` with sane volumes
- [x] Cross section: ran with/without `--no-resin-support`, at angle 0 (lands on a resin-rod symmetry plane) and off-axis (7.3°) - all watertight/volume-correct
- [x] Confirmed the default (no debug flags) path is byte-identical to before this change on all four machines (spot-checked Postal's exact summary line against the pre-change baseline)
- [x] Headless Textual pilot (scratch configs only): verified both Debug widgets exist with correct defaults, and that `_run_build` produces the correct `--cross-section-angle-deg`/`--cut-bodies` CLI args in all four on/off combinations, independently of each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)