### PR TITLE
v4: document simplified commit-to-main workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/settings.json

--- a/v4/CLAUDE.md
+++ b/v4/CLAUDE.md
@@ -1,5 +1,18 @@
 # v4 conventions
 
+## Workflow - commit directly to main by default
+
+For routine changes in this repo, edit files directly in the existing
+checkout and commit straight to `main` - no feature branch, no worktree,
+no PR, unless explicitly asked for one (a large/risky change the user
+wants reviewed separately, or an explicit "put this on a branch"/"open a
+PR"). `.claude/settings.json`'s `worktree.bgIsolation: "none"` disables
+the harness's default enforced-worktree-isolation behavior for
+background sessions in this repo specifically, so this applies to fresh
+agent sessions here too, not just interactive ones - don't reach for
+`EnterWorktree`/branch-and-PR as the default move just because that's
+the harness's out-of-the-box behavior elsewhere.
+
 ## Before writing new code
 
 Search `lib/cylinder_machine.py` (shared across cylinder machines) and the


### PR DESCRIPTION
## Summary
Per explicit user direction: for routine changes going forward, work directly in the checkout and commit straight to `main` - no feature branch, worktree, or PR unless the user actually asks for one. Adds a "Workflow" section documenting this as the first thing in `CLAUDE.md`.

Note: this PR does NOT include the `.claude/settings.json` change (`worktree.bgIsolation: "none"`) needed to actually disable the harness's enforced worktree-isolation for background sessions in this repo - committing that file was blocked by Claude Code's own auto-mode classifier (it flags changes to settings.json specifically). The user was given the file contents to add themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)