### PR TITLE
v4: fix Bennett tune.py crash from label.size_mm/font.size_mm key collision

### DIFF
--- a/v4/config/bennett.yaml
+++ b/v4/config/bennett.yaml
@@ -39,7 +39,14 @@ label:
   label1a: "Leonard"     # Shuttle_Label1a
   label1b: "Chau"        # Shuttle_Label1b
   label2: "2025"         # Shuttle_Label2
-  size_mm: 1.7           # Shuttle_Label_Size
+  label_size_mm: 1.7     # Shuttle_Label_Size - prefixed (unlike font.size_mm)
+  # because tune.py's patch_yaml_value() does a flat, section-unscoped
+  # regex search for the key name across the whole YAML text - two
+  # differently-scoped fields both literally named "size_mm" would
+  # collide there regardless of tune.py's own per-tab bookkeeping (this
+  # is exactly what broke Bennett's Font & Alignment tab: see git log).
+  # Mignon's own label.* keys (label_text_size_mm etc.) already follow
+  # this same convention for the same reason.
   # Z offset added to Bottom_Countersink_Depth for where the (fixed 2mm
   # deep, not itself configurable in v2 - see LabelText()) cut starts.
   depth_mm: 0.2          # Shuttle_Label_Depth

--- a/v4/lib/bennett.py
+++ b/v4/lib/bennett.py
@@ -108,7 +108,7 @@ def configure(config_path):
     g["Shuttle_Label1a"] = label["label1a"]
     g["Shuttle_Label1b"] = label["label1b"]
     g["Shuttle_Label2"] = label["label2"]
-    g["Shuttle_Label_Size"] = label["size_mm"]
+    g["Shuttle_Label_Size"] = label["label_size_mm"]
     g["Shuttle_Label_Depth"] = label["depth_mm"]
 
     e = cfg["element"]

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -469,7 +469,7 @@ LABEL_FIELDS_BENNETT = [
     ("label1a", ["label", "label1a"], str, "Label 1a (top line, right group)", "Shuttle_Label1a - e.g. a first name."),
     ("label1b", ["label", "label1b"], str, "Label 1b (bottom line, right group)", "Shuttle_Label1b - e.g. a last name."),
     ("label2", ["label", "label2"], str, "Label 2 (left group)", "Shuttle_Label2 - e.g. a year."),
-    ("label_size_mm", ["label", "size_mm"], float, "Label text size (mm)", ""),
+    ("label_size_mm", ["label", "label_size_mm"], float, "Label text size (mm)", ""),
     ("depth_mm", ["label", "depth_mm"], float, "Label depth offset (mm)", "Added to Bottom_Countersink_Depth for the cut's Z start."),
 ]
 


### PR DESCRIPTION
## Summary
Follow-up to #33. That PR fixed the `tune.py`-internal `self.inputs`/`self.FIELDS` collision between Bennett's Label tab and the shared Font & Alignment tab (both used the short key `size_mm`), but missed that `patch_yaml_value()` does a flat, section-unscoped regex search directly against the raw YAML text using that same short key - not the `(section, path)` tuple. Since the actual config field was still literally named `size_mm` under `label:`, saving from tune.py (Quick Preview/Render/etc.) crashed with:

```
ValueError: key 'label_size_mm' not found in config text - was it renamed/removed?
```

## Fix
Renamed the actual YAML key everywhere instead of just the tune.py-internal label:
- `config/bennett.yaml`: `label.size_mm` -> `label.label_size_mm` (with a comment explaining why, matching Mignon's existing `label_text_size_mm` convention for the same reason)
- `lib/bennett.py`'s `configure()` read site
- `tune.py`'s `LABEL_FIELDS_BENNETT` path

## Test plan
- [x] `py_compile` on `tune.py`/`lib/bennett.py`
- [x] `bennett.configure()` loads the renamed key correctly (`Shuttle_Label_Size == 1.7`)
- [x] Directly exercised `patch_yaml_value()` for both `"size_mm"` (font) and `"label_size_mm"` (label) against the real config text - each now patches its own distinct line, no collision
- [ ] Did not re-run the full `generate.py` geometry gate for this change (config-key-name-only, no geometry-affecting code touched) - flagging so it's not implicitly claimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)