### PR TITLE
v4: port IBM Selectric typeball (I/II, III, Composer) + tune.py wiring

### DIFF
--- a/v4/SESSION_LOG.md
+++ b/v4/SESSION_LOG.md
@@ -2785,6 +2785,200 @@ crash. CLI: `--hammond-part rib_only` still exports a valid RibOnly()
 ways (Resin supports off, no Minkowski) produces the same two distinct
 valid meshes the old FDM targets used to.
 
+## 40. IBM/Selectric port: Selectric I/II, Selectric III, Selectric Composer (all three, split per user request)
+
+User requested `v2/ibm.scad` be split into 3 separate v4 machines
+(Selectric I/II, Selectric Composer, Selectric III) rather than one
+`ibm.py` with a mode switch, plus a shared lib for the ~80% of the file
+that's byte-identical across the three v2 `Render_Mode` branches. Done
+in a worktree (`.claude/worktrees/selectric-port`, branch
+`worktree-selectric-port`) - not yet merged to main, pending user
+decision.
+
+**Audit pass**: diffed `v2/ibm.scad` (1045 lines) + `v2/lib/layouts/
+ibm_layouts.scad` (243 lines) function-by-function before writing
+anything, per CLAUDE.md's port process rule (see conversation - this
+wasn't skipped). Confirmed IBM/Selectric shares nothing structurally with
+`lib/cylinder_machine.py` (a different form factor, per CLAUDE.md's
+taxonomy) - new shared module `lib/spherical_machine.py` was written from
+scratch, not derived from the cylinder family.
+
+**Architecture**: `lib/spherical_machine.py` holds `FullBody`/
+`SolidCleanup`/`Teeth`/`Tooth`/`Notch`/the character-glyph pipeline
+(`SingleMinkowskiChar`/`AssembleMinkowski`)/labels (`Del`/`FontName`/
+`Labels`)/resin supports (`ResinRodAssemble`)/`TextGauge` - all
+byte-identical across the 3 v2 modes, just parametrized instead of
+`Render_Mode`-array-indexed. Three thin machine modules (`lib/
+selectric12.py`, `lib/selectric_composer.py`, `lib/selectric3.py`) each
+carry their own `configure()` + character/hemisphere layout data (`lib/
+layouts/selectric12_layout.py` / `selectric_composer_layout.py` /
+`selectric3_layout.py`) + one config YAML each (`config/selectric12.yaml`
+/ `selectric_composer.yaml` / `selectric3.yaml`), following the standard
+`configure(config_path)`/`_require_configured()`/`FullElement`/
+`ResinPrint`/`Additive` entry-point contract. Dynamic dispatch (
+`spherical_machine._receive_config`) mirrors `cylinder_machine.py`'s own
+mechanism exactly.
+
+**Character-embedding pipeline is a genuine reimplementation, not a
+`build_glyph()` reuse**: `build_glyph()`'s cylinder-family platen-cutout
+model doesn't directly generalize to the sphere - v2's real
+`PlatenCutout()` is built via its own independent rotate/translate stack
+sharing longitude/latitude with the character, not expressed relative to
+the character's own local frame the way `build_glyph()` assumes (worked
+this out by hand-deriving both transform stacks before writing code, see
+conversation). `SingleMinkowskiChar()` is a direct, literal port of v2's
+`Text()`/`PositionText()`/`PlatenCutout()`/`SingleMinkowski()`, reusing
+only `glyph_poc.py`'s low-level 2D contour-extraction helpers
+(`get_glyph_contours_and_advance`/`classify_and_triangulate`/
+`alignment_x_offset`), not its 3D placement/draft logic. Also notably
+different from `build_glyph()`'s order of operations: v2 POSITIONS the
+character in world coordinates FIRST, then Minkowski-sums with a draft
+cone built at the origin (rotated only, never translated) - verified by
+hand that this is still a correct local dilation (a Minkowski operand's
+absolute position doesn't matter, only its own point-set-as-offset-
+vectors), not "fixed" to match `build_glyph()`'s draft-then-place order.
+
+**Hemisphere layout data**: v2's keyboard-layout strings are OpenSCAD
+multi-line string literals indexed character-by-character including
+embedded newlines - not reproducible from the `.scad` source alone
+without a real OpenSCAD interpreter to test the exact indexing semantics
+against. Sidestepped: v2's own `S12_HEMISPHERE_MAP`/`S3_HEMISPHERE_MAP`/
+`COMPOSER_HEMISPHERE_MAP` are already precomputed, hardcoded permutation
+tables (the source comments say so explicitly) - copied verbatim into
+each `lib/layouts/*.py`, paired with the keyboard-order strings stripped
+of whitespace to a clean flat sequence, rather than re-deriving the
+permutation from scratch.
+
+**Resin supports**: per the user's own mid-session suggestion, reused
+`lib/resin_support.py`'s shared `resin_rod()`/`connecting_rod()` for
+every rod/strut in `ResinRodAssemble()`, rather than porting v2's
+`ResinRod`/`ResinTip` as bespoke angle-aware geometry. Turned out v2's
+own `a1` tilt-angle parameter on those two modules is dead code in the
+current file - every real call site in `ResinRodAssemble()` passes
+`a1=0` (the angle-tilted variants are commented out) - so no angle-aware
+system was actually needed; this is a real simplification (accepted,
+since resin supports are removed after printing, not part of the
+measured physical part), not an oversight - v2's `Rod_Base_C`/exact
+raft-chamfer proportions have no equivalent slot in the shared
+`resin_rod()` and are dropped, called out in each config's `resin:`
+comment rather than silently diverging.
+
+**Verified**: all 3 machines via `generate.py` with the REAL Minkowski
+draft (`--cone-segments 12`) and resin supports on (the actual hard-gate
+condition, not just an undrafted preview):
+
+```
+selectric12:         ResinPrint: verts=75003 faces=150214 watertight=True winding_consistent=True is_volume=True volume=7521.792mm3
+selectric3:           ResinPrint: verts=73387 faces=146982 watertight=True winding_consistent=True is_volume=True volume=7548.874mm3
+selectric_composer:   ResinPrint: verts=73923 faces=148062 watertight=True winding_consistent=True is_volume=True volume=7529.368mm3
+```
+
+All three volumes cluster tightly (~7.52-7.55cm3) - expected, since all
+3 modes share the same physical ball, and a useful independent
+cross-check that nothing was silently broken per-machine.
+`selectric_composer`'s build took considerably longer (CPU-bound,
+~15-20min vs ~5min for the other two) - not root-caused (candidates:
+a particularly complex glyph outline among its punctuation-heavy
+character set feeding a larger face count into `manifold3d`'s
+`minkowski_sum`, whose cost scales with the product of face counts; or
+CPU contention with another concurrent build on the same machine) -
+didn't block since it completed successfully, but worth investigating if
+it recurs. Confirmed via `git status` that only new files were added -
+no existing shared module (`cylinder_machine.py`/`scad_primitives.py`/
+`glyph_poc.py`/`resin_support.py`) was touched, so no regression risk to
+any other machine and no need to re-run the cross-machine hard-gate
+comparison.
+
+**Not yet done**: Calibration entry points (`CalibrationElement`/
+`CalibrationAdditive` not implemented - `tune.py`'s Calibration tab and
+Build-target option are correctly gated off rather than exposing a
+button that would crash, see below); drain holes (`Drain`, defaults off
+in v2, so no default-behavior gap); Composer's own pica/units type-test
+system (`TextGaugeComposerLine2`, genuinely different from Selectric I/II
+& III's shared CPI `TextGauge()` - `tune.py`'s generic Type Test tab
+still works for all 3, same "generic flat CPI/LPI preview, not
+machine-specific" convention every other machine already uses); non-US
+language variants (Composer's UK/Nordic/German/Latin, Selectric I/II's
+Custom layout). Composer's alignment offsets (`x_pos_offset`/
+`y_pos_offset`/alignment.mode) were carried over verified line-by-line
+against v2 per explicit user directive (print-critical) - still worth an
+actual rendered visual comparison against v2's own OpenSCAD output
+before calling that fully closed, not just a config-diff check.
+
+## 41. tune.py wired up for all 3 Selectric machines
+
+Follow-up to part 40 - user wanted to drive/inspect the port themselves
+via the TUI rather than through generated renders. Added all 3 machines
+(`selectric12`/`selectric3`/`selectric_composer`) to `tune.py`'s
+`MACHINES` dict plus new shared field tables (`FONT_FIELDS_SELECTRIC12`,
+`FONT_FIELDS_SELECTRIC_COMPOSER` - Composer sizes by cap-height, not
+direct point size, so gets its own Font & Alignment table -
+`ELEMENT_FIELDS_SELECTRIC`/`LABEL_FIELDS_SELECTRIC`/
+`QUALITY_FIELDS_SELECTRIC`/`RESIN_FIELDS_SELECTRIC`, shared across all 3
+since their config schema is byte-identical, unlike Bennett/Mignon/
+Helios which each needed fully separate tables).
+
+**Real, previously-latent `tune.py` bugs found and fixed while doing
+this** - not Selectric-specific hacks, genuine gaps the cylinder-family's
+uniformity had been masking:
+- `_load_machine()` unconditionally computed `len(self.cfg["layout"]
+  ["baseline_row"])` - KeyErrors immediately for any machine with no
+  editable keyboard-layout concept. Added `self.HAS_LAYOUT_TAB = "rows"
+  in self.cfg.get("layout", {})`, now gating the Layout tab
+  (`compose()`), `_compose_baseline_cutout_fields()`, and every
+  layout-touching branch in `_save_to_yaml`/`_refresh_widgets_from_cfg` -
+  same pattern as the existing `"Gauge" in self.SECTIONS` gate for
+  machines with no Shaft Gauge Test.
+- `compose()`/`_compose_build_tab()` treated the "Calibration" tab and
+  Build-target option as unconditional (every machine so far always
+  merged in `SECTIONS_COMMON`, which includes it) - now gated on
+  `"Calibration" in self.SECTIONS`, mirroring the Gauge pattern exactly.
+- `action_render_type_test()` hardcoded the cylinder-family's Font &
+  Alignment field key names (`self.inputs["mode"]`/`"center_offset_mm"`/
+  `"modified_left_chars"`/etc.) directly, and `self.inputs["size_mm"]`
+  for font size - both assumptions break for a machine with a genuinely
+  different alignment schema (Selectric's `custom_h_chars`/`x_pos_offset`
+  convention) or sizing convention (Composer's cap-height). Rewrote to
+  build the `type_test.py` command incrementally, checking `key in
+  self.inputs` before adding each optional flag, and deriving font_size_mm
+  from `composer_cap_height/2.834` when `size_mm` isn't present.
+
+**Config key collision caught before it caused silent data corruption**:
+`tune.py`'s `patch_yaml_value()` matches by bare key TEXT across the
+WHOLE file (not scoped by section), same reasoning as
+`LABEL_FIELDS_MIGNON`'s `label_`-prefixing. `font.path`/`font.size_mm`
+and `font2.path`/`font2.size_mm` would have collided (both literally
+`path:`/`size_mm:`) - renamed `font2:`'s keys to `font2_path`/
+`font2_size_mm`/`font2_chars` (`font2_composer_cap_height` for Composer)
+in all 3 configs and their `configure()` functions. Also renamed
+`alignment.h_alignment` to `alignment.mode` in all 3 configs to match
+`tune.py`'s existing generic center/left Select-widget convention
+(`_compose_section_tab`'s `elif key == "mode":` special case) - gets a
+proper dropdown for free instead of a plain text `Input`, and makes
+`action_render_type_test`'s `self.inputs["mode"]` lookup work unmodified
+for Selectric too.
+
+**Missing config keys found via testing, not inspection**: `build.target`
+(referenced by `_collect_values`/`_save_to_yaml` but absent from all 3
+YAMLs - `patch_yaml_value` only replaces existing keys, never inserts),
+`type_test.lpi` (assumed present by the generic Type Test tab), and
+`type_test.text` needed to be a YAML block scalar (`text: |-` + indented
+line) rather than a quoted string - `patch_yaml_text_block`'s regex
+requires the block form specifically.
+
+**Verified**: headless `TuneApp(...).run_test()` against scratch copies
+only (never the real master/running configs, per the standing warning) -
+for all 3 machines: `compose()` builds cleanly, a full `_collect_values`/
+`_save_to_yaml`/`_refresh_widgets_from_cfg` round-trip succeeds, and -
+critically - the REAL subprocess paths actually run to completion:
+`_run_build(fast=True)` (Quick Preview, calls `generate.py` for real) and
+`action_render_type_test()` (calls `type_test.py` for real, exercising
+Composer's cap-height font-size fallback specifically) both populate
+`_last_build_info`, confirming a real `returncode == 0`, not just "no
+Python exception." Machine-picker flow (`_select_machine`) uses the same
+`_load_machine()` path already covered by this testing, not separately
+exercised.
+
 ## Resuming later
 
 1. **Hammond follow-up work (parts 30-31)**: (a) DONE - `resin.
@@ -2796,11 +2990,15 @@ valid meshes the old FDM targets used to.
    (d) go through `tune.py`'s Hammond tabs field-by-field against
    `config/hammond.yaml` for anything still missing (named layout
    presets, Calibration wiring - see part 29's open items).
-2. **Hammond_split.scad and IBM are next** - `hammond.scad` itself is
-   done (part 29). `hammond_split.scad` turned out to share almost
-   nothing with `hammond.scad` (see part 29's audit) - treat it as its
-   own from-scratch port, not a quick follow-on. IBM (spherical) is still
-   fully unstarted.
+2. **Hammond_split.scad is next** - `hammond.scad` itself is done (part
+   29). `hammond_split.scad` turned out to share almost nothing with
+   `hammond.scad` (see part 29's audit) - treat it as its own
+   from-scratch port, not a quick follow-on. IBM/Selectric (parts 40-41)
+   is now built, verified, AND wired into `tune.py` for all 3 modes
+   (Selectric I/II, III, Composer) in a worktree, not yet merged -
+   remaining work there is Calibration entry points, drain holes,
+   Composer's pica type-test system, and non-US language variants (see
+   part 40/41).
 2. Bennett's port (between Mignon and Helios) has no `SESSION_LOG.md`
    chapter of its own - per CLAUDE.md, that's flagged as correlating with
    Bennett having more small undocumented inconsistencies than Mignon.

--- a/v4/config/selectric12.yaml
+++ b/v4/config/selectric12.yaml
@@ -1,0 +1,150 @@
+# Selectric I/II type element (88 chars, 4 rows x 22/row) - ported from
+# v2/ibm.scad's Render_Mode=1 branch (see that file for authoritative
+# source/comments) + v2/lib/layouts/ibm_layouts.scad's S12-specific
+# section. Physically identical typeball to Selectric Composer (same
+# sphere/skirt/boss/shaft dimensions) and near-identical to Selectric III
+# (which reuses S12's font-size/platen/offset values as its OWN starting
+# defaults per v2/ibm.scad:187-190,292-294 - NOT a cross-file reference,
+# each machine gets its own copy here). See lib/spherical_machine.py for
+# the shared geometry pipeline this config drives.
+
+machine: selectric12
+
+font:
+  # FreeSans is the standard metric-compatible substitute for v2's real
+  # value "Arial" (a system font name, not a file path) - same convention
+  # as config/postal.yaml's FreeMono substitution for "FreeMono:style=Bold".
+  path: "/home/lchau/fonts/Library/Sans Text/FreeSans.ttf"
+  size_mm: 2.4          # v2 Font_Size (ibm.scad:184) - S12 uses direct point size, not Composer's cap-height convention
+  name: "Arial"         # v2 Font - used ONLY as the literal engraved typeface-label text (FontName()), not for glyph rendering
+
+font2:
+  # FreeSerif is the standard substitute for v2's real value "Times New Roman"
+  # Keys are font2_-prefixed (not path/size_mm/chars) to avoid colliding
+  # with font:'s own keys - tune.py's patch_yaml_value matches by bare
+  # key text across the whole file, not by section (same reasoning as
+  # lib/mignon.py's LABEL_FIELDS_MIGNON prefixing, see tune.py).
+  font2_path: "/home/lchau/fonts/Library/Serif Text/FreeSerif.ttf"
+  font2_size_mm: 2.4          # v2 Font2_Size (ibm.scad:196)
+  font2_chars: ""             # v2 Font2_Chars (ibm.scad:205) - chars that adopt font2 instead of font
+
+alignment:
+  # "mode" (not h_alignment) - matches tune.py's generic center/left
+  # Select-widget convention (SECTIONS_COMMON's own alignment.mode field).
+  mode: "center"    # v2 All_H_Alignments[1] (ibm.scad:239)
+  x_pos_offset: 0.0        # v2 X_Pos_Offset_S12 (ibm.scad:226)
+  y_pos_offset: -1.5       # v2 Y_Pos_Offset_S12 (ibm.scad:228)
+  custom_h_chars: ""       # v2 CUSTOMHALIGNCHARS (ibm.scad:207)
+  custom_h_offset: 0.2     # v2 CUSTOMHALIGNOFFSET (ibm.scad:209)
+  custom_v_chars: ""       # v2 CUSTOMVALIGNCHARS (ibm.scad:211)
+  custom_v_offset: -0.2    # v2 CUSTOMVALIGNOFFSET (ibm.scad:213)
+
+element:
+  sphere_od: 33.4                 # v2 Sphere_OD (ibm.scad:309)
+  max_od: 34.9                    # v2 Max_OD (ibm.scad:313)
+  top_flat_to_center: 11.0        # v2 Top_Flat_To_Center (ibm.scad:315)
+  top_flat_thickness: 3.5         # v2 Top_Flat_Thickness (ibm.scad:277)
+  top_chamfer: 0.7                # v2 Top_Chamfer (ibm.scad:318)
+  inside_id: 28.15                # v2 Inside_ID (ibm.scad:320)
+  boss_od: 11.6                   # v2 Boss_OD (ibm.scad:283)
+  boss_clearance: 2.5             # v2 Boss_Clearance (ibm.scad:285)
+  boss_step: 0.0                  # v2 Boss_Step (ibm.scad:287)
+  boss_to_center_base: 2.5        # v2 Boss_To_Center_ (ibm.scad:322)
+  snoot_droop_compensation: 0.42  # v2 Snoot_Droop_Compensation (ibm.scad:302) - CRITICAL: measured boss-height calibration value, see v2's own echo() warning
+  shaft_id: 8.8                   # v2 Shaft_ID (ibm.scad:279)
+  skirt_top_od: 32.3              # v2 Skirt_Top_OD (ibm.scad:344)
+  skirt_bottom_od: 30.2           # v2 Skirt_Bottom_OD (ibm.scad:346)
+  platen_diameter: 36.0           # v2 Platen_OD_S12 (ibm.scad:291)
+  drive_notch_width: 1.06         # v2 Drive_Notch_Width (ibm.scad:297)
+  drive_notch_height: 2.2         # v2 Drive_Notch_Height (ibm.scad:299)
+  drive_notch_theta: 131.0        # v2 Drive_Notch_Theta_ (ibm.scad:358)
+  detent_valley_to_center: 6.0    # v2 Detent_Valley_To_Center (ibm.scad:360)
+  detent_skirt_clock_offset: 0.0  # v2 Detent_Skirt_Clock_Offset (ibm.scad:362)
+  # v2 Floor (ibm.scad:326) - "center to detent teeth tips of element";
+  # v2's own comment gives this as a measured reference value
+  # (abs(Top_Flat_To_Center-ELEMENT_OAT)=10.7 for the physical element
+  # Leo measured against - ELEMENT_OAT itself isn't a variable in v2,
+  # baked directly into this literal), not derived from other fields here.
+  floor: 10.7
+
+layout:
+  chars_per_row: 22               # v2 Chars_Per_Row_All[1] (ibm.scad:333)
+  # Reference count Tooth()'s profile was tuned for (v2 Chars_Per_Row_All[1]
+  # specifically, ALWAYS Selectric I/II's own count regardless of which
+  # mode is rendering - ibm.scad:718) - equal to chars_per_row for this
+  # machine itself, but Selectric III's config will set chars_per_row=24
+  # while this stays 22.
+  chars_per_row_reference: 22
+  hemisphere_cols_per_row: 11     # v2 Hemisphere_Cols_Per_Row_All[1] (ibm.scad:338)
+  row_latitudes: [32.8, 16.4, 0, -16.4]                  # v2 Row_Latitudes (ibm.scad:356) - shared physical ball, same for all 3 modes
+  platen_longitude_offsets: [-1.05, -1.05, -1.0, -1.05]  # v2 Platen_Longitude_Offsets (ibm.scad:122)
+  baseline_longitude_offsets: [0.0, 0.0, 0.0, 0.0]       # v2 Baseline_Longitude_Offsets (ibm.scad:398)
+  minkowski_longitudinal_offsets: [0.0, 0.0, 0.0, 0.0]   # v2 Minkowski_Longitudinal_Offsets (ibm.scad:79)
+
+label:
+  enabled: true                # v2 Label (ibm.scad:369)
+  arrow_enabled: true          # v2 Arrow (ibm.scad:371)
+  show_number: true            # v2: `if (Render_Mode!=0)` in Labels() (ibm.scad:988) - true for Selectric I/II and III, false for Composer
+  label_no: "10"                # v2 Label_No (ibm.scad:373)
+  label_text_override: ""       # v2 Label_Text_Override (ibm.scad:375)
+  label_no_font_override: ""    # v2 Label_No_Font_Override (ibm.scad:377)
+  label_font_override: ""       # v2 Label_Font_Override (ibm.scad:379)
+  no_label_size: 2.0            # v2 No_Label_Size (ibm.scad:381)
+  no_label_offset: 0.0          # v2 No_Label_Offset (ibm.scad:383)
+  font_label_size: 2.0          # v2 Font_Label_Size (ibm.scad:385)
+  font_label_offset: 0.0        # v2 Font_Label_Offset (ibm.scad:389)
+  del_base_from_centre: 8.2     # v2 Del_Base_From_Centre (ibm.scad:391)
+  del_depth: 0.6                # v2 Del_Depth (ibm.scad:393)
+
+build:
+  points_per_mm: 8.0
+  draft_angle_deg: 55.0            # v2 Mink_Draft_Angle (ibm.scad:65)
+  minkowski_enabled: true          # v2 Mink_On (ibm.scad:63)
+  # v2's linear_extrude(6) in PositionText's child (ibm.scad:521-524) - a
+  # construction margin (must be taller than any character's real embed
+  # depth), not itself a measured physical dimension, but still a
+  # geometry-affecting constant per CLAUDE.md, so it's config-driven
+  # rather than hardcoded.
+  character_block_height_mm: 6.0
+  # v2's hardcoded cylinder(...,h=2) inside the minkowski draft cone
+  # (ibm.scad:575,581) - same reasoning as character_block_height_mm above.
+  mink_cone_height_mm: 2.0
+  resin_support: true
+  target: "element"
+
+quality:
+  surface_fn: 120       # v2 Surface_Fn (ibm.scad:48)
+  cyl_fn: 360           # v2 Cyl_Fn (ibm.scad:46)
+  minkowski_fn: 20      # v2 Mink_Fn (ibm.scad:42)
+
+resin:
+  # v2's ResinRod()/ResinTip() (ibm.scad:753-787) use a different raft/
+  # base-chamfer shape than v4's shared resin_support.resin_rod() (see
+  # lib/spherical_machine.py's ResinRodAssemble docstring) - resin
+  # supports are removed after printing (not part of the measured
+  # physical part), so this reuses the same shared geometry every other
+  # v4 machine's resin support already does, rather than replicating v2's
+  # exact chamfer ratios. v2's Rod_Base_C (0.5, the base-rod chamfer size)
+  # has no equivalent slot in resin_support.resin_rod() and is dropped -
+  # not silently: this comment is that callout.
+  resin_fn: 20                    # not an explicit v2 variable (IBM relies on the global $fn=44 default for these) - matches the majority resin.resin_fn convention
+  tip_od: 0.9                     # v2 Tip_D (ibm.scad:434)
+  tip_notch_od: 0.4               # v2 Tip_Notch_D (ibm.scad:436)
+  tip_notch_offset: 12.0          # v2 Tip_Notch_Offset (ibm.scad:438)
+  tip_in: 0.4                     # v2 Tip_In (ibm.scad:440)
+  tip_h: 1.0                      # v2 Tip_H (ibm.scad:442)
+  rod_od: 1.2                     # v2 Rod_D (ibm.scad:444)
+  base_od: 4.0                    # v2 Base_D (ibm.scad:450) - mapped to resin_support's raft_od
+  base_h: 2.0                     # v2 Base_H (ibm.scad:452) - mapped to resin_support's raft_thickness
+  min_rod_h: 2.0                  # v2 Min_Rod_H (ibm.scad:454)
+  resin_detent_clock_offset: 0.0  # v2 Resin_Detent_Clock_Offset (ibm.scad:460)
+
+output:
+  directory: "output"
+  stl_name: "selectric12_running.stl"
+
+type_test:
+  cpi: 10.0                                              # v2 Test_CPI (ibm.scad:259)
+  lpi: 6.0                                               # tune.py's generic Type Test tab convention (not a v2/real-element concept - see config/blickensderfer.yaml's matching comment)
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/config/selectric3.yaml
+++ b/v4/config/selectric3.yaml
@@ -1,0 +1,130 @@
+# Selectric III type element (96 chars, 4 rows x 24/row) - ported from
+# v2/ibm.scad's Render_Mode=2 branch (see that file for authoritative
+# source/comments) + v2/lib/layouts/ibm_layouts.scad's S3-specific
+# section. Physically the SAME sphere/skirt/boss/shaft as Selectric I/II
+# and Composer - Selectric III reuses Selectric I/II's font-size/platen/
+# offset values as its OWN starting defaults per v2/ibm.scad:187-190,
+# 292-294 (NOT a cross-file reference - this is its own independent copy
+# of those numbers, tunable separately if Selectric III ever needs to
+# diverge). See lib/spherical_machine.py for the shared geometry pipeline
+# this config drives.
+
+machine: selectric3
+
+font:
+  # Same substitute as config/selectric12.yaml (v2's real value is the
+  # system font name "Arial")
+  path: "/home/lchau/fonts/Library/Sans Text/FreeSans.ttf"
+  size_mm: 2.4          # v2 Font_Size (ibm.scad:184) - S3 reuses S12's Font_Size directly (All_Font_Sizes[2]=Font_Size), own copy here
+  name: "Arial"         # v2 Font - engraved typeface-label text only
+
+font2:
+  # font2_-prefixed keys - see config/selectric12.yaml's matching comment
+  # (tune.py's patch_yaml_value matches by bare key text file-wide).
+  font2_path: "/home/lchau/fonts/Library/Serif Text/FreeSerif.ttf"
+  font2_size_mm: 2.4          # v2 Font2_Size (ibm.scad:196) - S3 reuses S12's Font2_Size directly (All_Font2_Sizes[2]=Font2_Size)
+  font2_chars: ""             # v2 Font2_Chars (ibm.scad:205)
+
+alignment:
+  mode: "center"    # v2 All_H_Alignments[2] (ibm.scad:239) - same as S12
+  x_pos_offset: 0.0        # v2 All_X_Offsets[2]=X_Pos_Offset_S12 (ibm.scad:233,226) - S3 reuses S12's value directly
+  y_pos_offset: -1.5       # v2 All_Y_Offsets[2]=Y_Pos_Offset_S12 (ibm.scad:231,228) - S3 reuses S12's value directly
+  custom_h_chars: ""       # v2 CUSTOMHALIGNCHARS (ibm.scad:207)
+  custom_h_offset: 0.2     # v2 CUSTOMHALIGNOFFSET (ibm.scad:209)
+  custom_v_chars: ""       # v2 CUSTOMVALIGNCHARS (ibm.scad:211)
+  custom_v_offset: -0.2    # v2 CUSTOMVALIGNOFFSET (ibm.scad:213)
+
+element:
+  # Physically the SAME ball as Selectric I/II (see module comment above) -
+  # every value in this section is identical to config/selectric12.yaml's,
+  # each its own independent copy per the multi-config convention.
+  sphere_od: 33.4
+  max_od: 34.9
+  top_flat_to_center: 11.0
+  top_flat_thickness: 3.5
+  top_chamfer: 0.7
+  inside_id: 28.15
+  boss_od: 11.6
+  boss_clearance: 2.5
+  boss_step: 0.0
+  boss_to_center_base: 2.5
+  snoot_droop_compensation: 0.42
+  shaft_id: 8.8
+  skirt_top_od: 32.3
+  skirt_bottom_od: 30.2
+  platen_diameter: 36.0            # v2 Platen_OD_All[2]=Platen_OD_S12 (ibm.scad:294,291) - S3 reuses S12's platen directly
+  drive_notch_width: 1.06
+  drive_notch_height: 2.2
+  drive_notch_theta: 131.0
+  detent_valley_to_center: 6.0
+  detent_skirt_clock_offset: 0.0
+  floor: 10.7
+
+layout:
+  chars_per_row: 24                # v2 Chars_Per_Row_All[2] (ibm.scad:333)
+  # Tooth()'s profile reference count is ALWAYS Selectric I/II's own 22
+  # (v2 Chars_Per_Row_All[1], hardcoded in Tooth() regardless of which
+  # mode is rendering - ibm.scad:718) - narrows Selectric III's teeth to
+  # match its tighter 24-per-row spacing (scale_y=22/24).
+  chars_per_row_reference: 22
+  hemisphere_cols_per_row: 12      # v2 Hemisphere_Cols_Per_Row_All[2] (ibm.scad:338)
+  row_latitudes: [32.8, 16.4, 0, -16.4]                  # v2 Row_Latitudes (ibm.scad:356) - shared physical ball, same for all 3 modes
+  platen_longitude_offsets: [-1.05, -1.05, -1.0, -1.05]  # v2 Platen_Longitude_Offsets (ibm.scad:122) - same default array used for all modes
+  baseline_longitude_offsets: [0.0, 0.0, 0.0, 0.0]       # v2 Baseline_Longitude_Offsets (ibm.scad:398)
+  minkowski_longitudinal_offsets: [0.0, 0.0, 0.0, 0.0]   # v2 Minkowski_Longitudinal_Offsets (ibm.scad:79)
+
+label:
+  enabled: true
+  arrow_enabled: true
+  show_number: true             # v2: `if (Render_Mode!=0)` (ibm.scad:988) - true for Selectric III
+  label_no: "10"
+  label_text_override: ""
+  label_no_font_override: ""
+  label_font_override: ""
+  no_label_size: 2.0
+  no_label_offset: 0.0
+  font_label_size: 2.0
+  font_label_offset: 0.0
+  del_base_from_centre: 8.2
+  del_depth: 0.6
+
+build:
+  points_per_mm: 8.0
+  draft_angle_deg: 55.0
+  minkowski_enabled: true
+  character_block_height_mm: 6.0
+  mink_cone_height_mm: 2.0
+  resin_support: true
+  target: "element"
+
+quality:
+  surface_fn: 120
+  cyl_fn: 360
+  minkowski_fn: 20
+
+resin:
+  # See config/selectric12.yaml's matching comment - v2's Rod_Base_C has
+  # no equivalent slot in the shared resin_support.resin_rod(), dropped
+  # (resin supports are removed after printing, not part of the measured
+  # physical part).
+  resin_fn: 20
+  tip_od: 0.9
+  tip_notch_od: 0.4
+  tip_notch_offset: 12.0
+  tip_in: 0.4
+  tip_h: 1.0
+  rod_od: 1.2
+  base_od: 4.0
+  base_h: 2.0
+  min_rod_h: 2.0
+  resin_detent_clock_offset: 0.0
+
+output:
+  directory: "output"
+  stl_name: "selectric3_running.stl"
+
+type_test:
+  cpi: 10.0
+  lpi: 6.0
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/config/selectric_composer.yaml
+++ b/v4/config/selectric_composer.yaml
@@ -1,0 +1,142 @@
+# Selectric Composer type element (88 chars, 4 rows x 22/row) - ported
+# from v2/ibm.scad's Render_Mode=0 branch (see that file for authoritative
+# source/comments) + v2/lib/layouts/ibm_layouts.scad's Composer-specific
+# section. Physically the SAME sphere/skirt/boss/shaft as Selectric I/II
+# and III, but with its OWN font-sizing convention (cap-height, not direct
+# point size), its OWN alignment offsets, and a larger platen (43mm vs
+# 36mm). US language only for now (v2 also has UK/Nordic/German/Latin/
+# Custom - see lib/layouts/selectric_composer_layout.py's docstring).
+#
+# alignment.x_pos_offset/y_pos_offset/custom_h_offset/custom_v_offset/
+# h_alignment below are PRINT-CRITICAL - explicit user directive during
+# this port: Composer's glyph alignment must be preserved byte-exact from
+# v2, not approximated or defaulted. Do not change these values without
+# re-verifying against v2/ibm.scad's own X_Pos_Offset_Composer_/
+# Y_Pos_Offset_Composer/All_H_Alignments[0].
+
+machine: selectric_composer
+
+font:
+  path: "/home/lchau/fonts/Library/Sans Text/FreeSans.ttf"   # substitute for v2's "Arial", same as config/selectric12.yaml
+  # Composer sizes type by CAP HEIGHT (in points), not direct point size -
+  # v2: Font_Size_Selected = Composer_Cap_Height/2.834 (ibm.scad:186,190).
+  # This is a fixed numeric conversion (matches v2 exactly), not a real
+  # FreeType cap-height measurement/solve.
+  composer_cap_height: 7.0
+  name: "Arial"          # v2 Font - engraved typeface-label text only
+
+font2:
+  # font2_-prefixed keys - avoids colliding with font:'s own key text
+  # (tune.py's patch_yaml_value matches by bare key across the whole
+  # file, not by section - same reasoning as config/selectric12.yaml).
+  font2_path: "/home/lchau/fonts/Library/Serif Text/FreeSerif.ttf"  # substitute for v2's "Times New Roman"
+  font2_composer_cap_height: 7.0   # v2 Composer2_Cap_Height (ibm.scad:198)
+  font2_chars: ""                  # v2 Font2_Chars (ibm.scad:205)
+
+alignment:
+  # "mode" (not h_alignment) - matches tune.py's generic center/left
+  # Select-widget convention. CRITICAL: "left" here, not "center" - see
+  # file header comment.
+  mode: "left"       # v2 All_H_Alignments[0] (ibm.scad:239) - CRITICAL, see file header comment
+  x_pos_offset: 1.20        # v2 X_Pos_Offset_Composer_ (ibm.scad:221) - CRITICAL, see file header comment
+  y_pos_offset: -1.30       # v2 Y_Pos_Offset_Composer (ibm.scad:224) - CRITICAL, see file header comment
+  custom_h_chars: ""        # v2 CUSTOMHALIGNCHARS (ibm.scad:207)
+  custom_h_offset: 0.2      # v2 CUSTOMHALIGNOFFSET (ibm.scad:209)
+  custom_v_chars: ""        # v2 CUSTOMVALIGNCHARS (ibm.scad:211)
+  custom_v_offset: -0.2     # v2 CUSTOMVALIGNOFFSET (ibm.scad:213)
+
+element:
+  # Physically the SAME ball as Selectric I/II/III - see file header comment.
+  sphere_od: 33.4
+  max_od: 34.9
+  top_flat_to_center: 11.0
+  top_flat_thickness: 3.5
+  top_chamfer: 0.7
+  inside_id: 28.15
+  boss_od: 11.6
+  boss_clearance: 2.5
+  boss_step: 0.0
+  boss_to_center_base: 2.5
+  snoot_droop_compensation: 0.42
+  shaft_id: 8.8
+  skirt_top_od: 32.3
+  skirt_bottom_od: 30.2
+  platen_diameter: 43.0            # v2 Platen_OD_C (ibm.scad:289) - Composer's own, larger platen
+  drive_notch_width: 1.06
+  drive_notch_height: 2.2
+  drive_notch_theta: 131.0
+  detent_valley_to_center: 6.0
+  detent_skirt_clock_offset: 0.0
+  floor: 10.7
+
+layout:
+  chars_per_row: 22                # v2 Chars_Per_Row_All[0] (ibm.scad:333) - same class as Selectric I/II
+  chars_per_row_reference: 22      # Tooth()'s own reference count - equal here, no narrowing needed
+  hemisphere_cols_per_row: 11      # v2 Hemisphere_Cols_Per_Row_All[0] (ibm.scad:338)
+  row_latitudes: [32.8, 16.4, 0, -16.4]                  # v2 Row_Latitudes (ibm.scad:356) - shared physical ball
+  platen_longitude_offsets: [-1.05, -1.05, -1.0, -1.05]  # v2 Platen_Longitude_Offsets (ibm.scad:122)
+  baseline_longitude_offsets: [0.0, 0.0, 0.0, 0.0]       # v2 Baseline_Longitude_Offsets (ibm.scad:398)
+  minkowski_longitudinal_offsets: [0.0, 0.0, 0.0, 0.0]   # v2 Minkowski_Longitudinal_Offsets (ibm.scad:79)
+
+label:
+  enabled: true
+  arrow_enabled: true
+  show_number: false            # v2: `if (Render_Mode!=0)` (ibm.scad:988) - FALSE for Composer (Render_Mode==0)
+  label_no: "10"
+  label_text_override: ""
+  label_no_font_override: ""
+  label_font_override: ""
+  no_label_size: 2.0
+  no_label_offset: 0.0
+  font_label_size: 2.0
+  font_label_offset: 0.0
+  del_base_from_centre: 8.2
+  del_depth: 0.6
+
+build:
+  points_per_mm: 8.0
+  draft_angle_deg: 55.0
+  minkowski_enabled: true
+  character_block_height_mm: 6.0
+  mink_cone_height_mm: 2.0
+  resin_support: true
+  target: "element"
+
+quality:
+  surface_fn: 120
+  cyl_fn: 360
+  minkowski_fn: 20
+
+resin:
+  resin_fn: 20
+  tip_od: 0.9
+  tip_notch_od: 0.4
+  tip_notch_offset: 12.0
+  tip_in: 0.4
+  tip_h: 1.0
+  rod_od: 1.2
+  base_od: 4.0
+  base_h: 2.0
+  min_rod_h: 2.0
+  resin_detent_clock_offset: 0.0
+
+output:
+  directory: "output"
+  stl_name: "selectric_composer_running.stl"
+
+# Composer's OWN pica/units type-test system (TextGaugeComposerLine2,
+# Composer_Pitch_List) is genuinely different from Selectric I/II & III's
+# CPI TextGauge - NOT wired into type_test.py yet in this pass (deferred,
+# same as Calibration/drain holes for the other two Selectric machines -
+# doesn't affect FullElement/ResinPrint, only a separate print-test-gauge
+# render variant). units_per_inch below is kept for when that lands.
+type_test:
+  units_per_inch: 72     # v2 Units_Per_Inch (ibm.scad:261) - [72:Red, 84:Yellow, 96:Blue]
+  # cpi/lpi: tune.py's generic Type Test tab convention (a v4-only flat
+  # CPI/LPI preview shared by every machine, independent of the real
+  # element pipeline) - not the same as units_per_inch above (Composer's
+  # own real pica/units type-test system, not wired up yet).
+  cpi: 10.0
+  lpi: 6.0
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/lib/layouts/selectric12_layout.py
+++ b/v4/lib/layouts/selectric12_layout.py
@@ -1,0 +1,74 @@
+"""
+Selectric I/II 88-character keyboard/hemisphere layout data - ported from
+v2/lib/layouts/ibm_layouts.scad's S12-specific section (LOWERCASE88_US/
+UPPERCASE88_US/S12_LC_HEMISPHERE88_US/S12_HEMISPHERE_MAP, ~lines 12-40 and
+216-222).
+
+v2's layout strings are OpenSCAD multi-line string literals indexed
+character-by-character including embedded newlines - CASES88[case][i] for
+i in [0:43] only lines up with real keyboard characters if the reader
+already knows OpenSCAD's exact string-literal newline semantics, which
+isn't reproducible from the .scad source alone without a real OpenSCAD
+interpreter to test against. Sidestepped here: v2's own
+S12_HEMISPHERE_MAP is already a PRECOMPUTED, hardcoded permutation table
+(44 entries, the comment above it in v2 says so explicitly) - copied
+verbatim below, not re-derived. The keyboard-order strings are stripped
+of all whitespace/newlines to a clean 44-character sequence (reading
+order: row 0 left-to-right, then row 1, etc.) - self-consistent with
+S12_HEMISPHERE_MAP's indices, which must refer to the same "real
+characters only, in reading order" positions for the original v2 model
+to have produced a sane typeball layout at all.
+
+Physical layout: 4 rows x 11 hemisphere columns = 44 keyboard positions
+per case; lowercase (case 0) and uppercase (case 1) sit on OPPOSITE
+hemispheres (180 degrees apart) - see v2/ibm.scad:330-338,610-655.
+"""
+
+CHARS_PER_ROW = 22
+HEMISPHERE_COLS_PER_ROW = 11
+TOTAL_CHARS = 88
+
+# v2/lib/layouts/ibm_layouts.scad:12-19 (LOWERCASE88_US), stripped of the
+# leading/trailing/row-separating newlines that make the source read like
+# a physical keyboard grid.
+LOWERCASE88_US = "".join("""
+1234567890-=
+qwertyuiop½
+asdfghjkl;'
+zxcvbnm,./
+""".split("\n"))
+
+# v2/lib/layouts/ibm_layouts.scad:21-27 (UPPERCASE88_US)
+UPPERCASE88_US = "".join("""
+!@#$%¢&*()_+
+QWERTYUIOP¼
+ASDFGHJKL:"
+ZXCVBNM,.?
+""".split("\n"))
+
+assert len(LOWERCASE88_US) == TOTAL_CHARS // 2 == 44
+assert len(UPPERCASE88_US) == 44
+
+# v2/lib/layouts/ibm_layouts.scad:222 - precomputed keyboard-index ->
+# hemisphere-index permutation (44 entries, one per LOWERCASE88_US
+# position). Copied verbatim, not re-derived (see module docstring).
+S12_HEMISPHERE_MAP = [
+    10, 4, 9, 6, 3, 2, 8, 7, 0, 1, 33, 37, 35, 22, 14, 30, 16, 34, 20, 24,
+    28, 36, 27, 29, 23, 19, 42, 43, 12, 38, 13, 17, 41, 25, 5, 21, 18, 31,
+    11, 15, 32, 40, 26, 39,
+]
+assert len(S12_HEMISPHERE_MAP) == 44
+
+
+def longitude_latitude():
+    """v2's LONGITUDE_LATITUDE (ibm.scad:243, S12-specialized): for each
+    keyboard index i, [longitude_col, latitude_row, lowercase_char,
+    keyboard_index]. longitude_col/latitude_row are derived from
+    S12_HEMISPHERE_MAP[i] % / // HEMISPHERE_COLS_PER_ROW - the hemisphere
+    permutation's own column/row within the 11-wide physical ring."""
+    return [
+        (S12_HEMISPHERE_MAP[i] % HEMISPHERE_COLS_PER_ROW,
+         S12_HEMISPHERE_MAP[i] // HEMISPHERE_COLS_PER_ROW,
+         LOWERCASE88_US[i], i)
+        for i in range(44)
+    ]

--- a/v4/lib/layouts/selectric3_layout.py
+++ b/v4/lib/layouts/selectric3_layout.py
@@ -1,0 +1,66 @@
+"""
+Selectric III 96-character keyboard/hemisphere layout data - ported from
+v2/lib/layouts/ibm_layouts.scad's S3-specific section (LOWERCASE96_US/
+UPPERCASE96_US/S3_LC_HEMISPHERE96/S3_HEMISPHERE_MAP, ~lines 55-93).
+
+Same "keyboard-order strings stripped of whitespace, hemisphere
+permutation table copied verbatim" approach as
+lib/layouts/selectric12_layout.py - see that module's docstring for why.
+Note the 5 physical print-lines in the v2 source (13+12+11+10+2=48
+characters) do NOT correspond to the ball's 4 physical rows - that's a
+keyboard-typing-layout artifact only; the real row assignment comes from
+S3_HEMISPHERE_MAP[i] // HEMISPHERE_COLS_PER_ROW, same formula as S12.
+
+Physical layout: 4 rows x 12 hemisphere columns = 48 keyboard positions
+per case; lowercase (case 0) and uppercase (case 1) sit on OPPOSITE
+hemispheres, 180 degrees apart - see v2/ibm.scad:330-338,610-655. The
+extra ²/§/³/¶ characters (on the physical ball but not reachable via the
+real Selectric III keyboard, per the reference repo this was sourced
+from) are included since they occupy real hemisphere positions.
+"""
+
+CHARS_PER_ROW = 24
+HEMISPHERE_COLS_PER_ROW = 12
+TOTAL_CHARS = 96
+
+# v2/lib/layouts/ibm_layouts.scad:56-62 (LOWERCASE96_US)
+LOWERCASE96_US = "".join("""
+±1234567890-=
+qwertyuiop½]
+asdfghjkl;'
+zxcvbnm,./
+²§
+""".split("\n"))
+
+# v2/lib/layouts/ibm_layouts.scad:65-71 (UPPERCASE96_US)
+UPPERCASE96_US = "".join("""
+°!@#$%¢&*()_+
+QWERTYUIOP¼[
+ASDFGHJKL:"
+ZXCVBNM,.?
+³¶
+""".split("\n"))
+
+assert len(LOWERCASE96_US) == TOTAL_CHARS // 2 == 48
+assert len(UPPERCASE96_US) == 48
+
+# v2/lib/layouts/ibm_layouts.scad:93 - precomputed keyboard-index ->
+# hemisphere-index permutation (48 entries). Copied verbatim, not
+# re-derived (see module docstring).
+S3_HEMISPHERE_MAP = [
+    35, 37, 4, 10, 7, 3, 6, 2, 8, 9, 5, 36, 23, 40, 26, 17, 29, 16, 42, 21,
+    14, 28, 41, 34, 46, 31, 15, 27, 43, 45, 33, 39, 20, 44, 12, 13, 0, 32,
+    18, 24, 19, 30, 25, 47, 38, 11, 1, 22,
+]
+assert len(S3_HEMISPHERE_MAP) == 48
+
+
+def longitude_latitude():
+    """v2's LONGITUDE_LATITUDE (ibm.scad:243, S3-specialized) - see
+    lib/layouts/selectric12_layout.py's matching function docstring."""
+    return [
+        (S3_HEMISPHERE_MAP[i] % HEMISPHERE_COLS_PER_ROW,
+         S3_HEMISPHERE_MAP[i] // HEMISPHERE_COLS_PER_ROW,
+         LOWERCASE96_US[i], i)
+        for i in range(48)
+    ]

--- a/v4/lib/layouts/selectric_composer_layout.py
+++ b/v4/lib/layouts/selectric_composer_layout.py
@@ -1,0 +1,61 @@
+"""
+Selectric Composer 88-character keyboard/hemisphere layout data - ported
+from v2/lib/layouts/ibm_layouts.scad's Composer-specific section
+(LOWERCASECOMPOSER_US/UPPERCASECOMPOSER_US/C_US_HEMISPHERE88/
+COMPOSER_HEMISPHERE_MAP, ~lines 97-231). US language only
+(Composer_Language==0) - v2 also has UK/Nordic/German/Latin/Custom
+variants (ALL_C in ibm_layouts.scad:197); not ported here, deferred the
+same way lib/layouts/selectric12_layout.py defers S12_88_Language's
+Custom variant.
+
+Same "keyboard-order strings stripped of whitespace, hemisphere
+permutation table copied verbatim" approach as
+lib/layouts/selectric12_layout.py - see that module's docstring for why.
+Composer shares the SAME physical ball/hemisphere geometry class as
+Selectric I/II (88 chars, 4 rows x 11 hemisphere columns) - only the
+keyboard layout and hemisphere mapping differ.
+"""
+
+CHARS_PER_ROW = 22
+HEMISPHERE_COLS_PER_ROW = 11
+TOTAL_CHARS = 88
+
+# v2/lib/layouts/ibm_layouts.scad:100-105 (LOWERCASECOMPOSER_US)
+LOWERCASECOMPOSER_US = "".join("""
+1234567890-=
+qwertyuiop?
+asdfghjkl][
+zxcvbnm,.;
+""".split("\n"))
+
+# v2/lib/layouts/ibm_layouts.scad:118-123 (UPPERCASECOMPOSER_US)
+UPPERCASECOMPOSER_US = "".join("""
+!†+$%/&*()–@
+QWERTYUIOP¾
+ASDFGHJKL¼½
+ZXCVBNM‘’:
+""".split("\n"))
+
+assert len(LOWERCASECOMPOSER_US) == TOTAL_CHARS // 2 == 44
+assert len(UPPERCASECOMPOSER_US) == 44
+
+# v2/lib/layouts/ibm_layouts.scad:231 - precomputed keyboard-index ->
+# hemisphere-index permutation (44 entries). Copied verbatim, not
+# re-derived (see module docstring).
+COMPOSER_HEMISPHERE_MAP = [
+    6, 9, 3, 4, 21, 2, 20, 10, 8, 7, 12, 33, 41, 31, 38, 28, 18, 37, 24, 16,
+    29, 36, 11, 17, 5, 30, 39, 40, 26, 43, 32, 15, 34, 13, 35, 22, 14, 23,
+    19, 27, 25, 1, 0, 42,
+]
+assert len(COMPOSER_HEMISPHERE_MAP) == 44
+
+
+def longitude_latitude():
+    """v2's LONGITUDE_LATITUDE (ibm.scad:243, Composer-specialized) - see
+    lib/layouts/selectric12_layout.py's matching function docstring."""
+    return [
+        (COMPOSER_HEMISPHERE_MAP[i] % HEMISPHERE_COLS_PER_ROW,
+         COMPOSER_HEMISPHERE_MAP[i] // HEMISPHERE_COLS_PER_ROW,
+         LOWERCASECOMPOSER_US[i], i)
+        for i in range(44)
+    ]

--- a/v4/lib/selectric12.py
+++ b/v4/lib/selectric12.py
@@ -1,0 +1,158 @@
+"""
+v4 Selectric I/II typeball - ports the Render_Mode==1 branch of
+v2/ibm.scad (+ v2/lib/layouts/ibm_layouts.scad's S12-specific section).
+
+All real-machine numbers live in config/selectric12.yaml, not here - call
+configure(path) once before using anything else in this module (see
+generate.py).
+
+Everything structurally shared with Selectric Composer/Selectric III
+(FullBody/SolidCleanup/Teeth/Notch/the character-glyph pipeline/labels/
+resin supports) lives in lib/spherical_machine.py - see that module's
+docstring for the dynamic-dispatch mechanism (mirrors lib/
+cylinder_machine.py's). Only the character/hemisphere layout data (lib/
+layouts/selectric12_layout.py) and this configure() are Selectric-I/II-
+specific; Selectric I/II and III additionally share the CPI/monospaced
+TextGauge() type-test convention (in spherical_machine.py) - Composer's
+own pica-based type test is genuinely different code, living in
+lib/selectric_composer.py instead.
+"""
+
+import yaml
+
+import spherical_machine
+from spherical_machine import FullElement, ResinPrint, Additive, TextGauge  # re-exported for callers
+from layouts.selectric12_layout import LOWERCASE88_US, UPPERCASE88_US, longitude_latitude
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    g["Font_Size"] = font["size_mm"]
+    g["FONT_NAME"] = font["name"]
+
+    font2 = cfg["font2"]
+    g["FONT2_PATH"] = font2["font2_path"]
+    g["Font2_Size"] = font2["font2_size_mm"]
+    g["Font2_Chars"] = font2["font2_chars"]
+
+    align = cfg["alignment"]
+    g["H_Alignment"] = align["mode"]
+    g["X_Pos_Offset"] = align["x_pos_offset"]
+    g["Y_Pos_Offset"] = align["y_pos_offset"]
+    g["CUSTOMHALIGNCHARS"] = align["custom_h_chars"]
+    g["CUSTOMHALIGNOFFSET"] = align["custom_h_offset"]
+    g["CUSTOMVALIGNCHARS"] = align["custom_v_chars"]
+    g["CUSTOMVALIGNOFFSET"] = align["custom_v_offset"]
+
+    e = cfg["element"]
+    g["Sphere_OD"] = e["sphere_od"]
+    g["Sphere_R"] = e["sphere_od"] / 2.0
+    g["Max_OD"] = e["max_od"]
+    g["Type_Altitude"] = (e["max_od"] - e["sphere_od"]) / 2.0
+    g["Top_Flat_To_Center"] = e["top_flat_to_center"]
+    g["Top_Flat_Thickness"] = e["top_flat_thickness"]
+    g["Top_Flat_R"] = (g["Sphere_R"] ** 2 - e["top_flat_to_center"] ** 2) ** 0.5
+    g["Top_Chamfer"] = e["top_chamfer"]
+    g["Inside_ID"] = e["inside_id"]
+    g["Inside_R"] = e["inside_id"] / 2.0
+    g["Boss_OD"] = e["boss_od"]
+    g["Boss_R"] = e["boss_od"] / 2.0
+    g["Boss_Clearance"] = e["boss_clearance"]
+    g["Boss_Step"] = e["boss_step"]
+    g["Boss_To_Center"] = e["boss_to_center_base"] + e["snoot_droop_compensation"]
+    g["Snoot_Droop_Compensation"] = e["snoot_droop_compensation"]
+    g["Shaft_ID"] = e["shaft_id"]
+    g["Skirt_Top_OD"] = e["skirt_top_od"]
+    g["Skirt_Bottom_OD"] = e["skirt_bottom_od"]
+    skirt_top_r = e["skirt_top_od"] / 2.0
+    g["Center_To_Skirt"] = (g["Sphere_R"] ** 2 - skirt_top_r ** 2) ** 0.5
+    g["Platen_OD"] = e["platen_diameter"]
+    g["Drive_Notch_Width"] = e["drive_notch_width"]
+    g["Drive_Notch_Height"] = e["drive_notch_height"]
+    g["Detent_Skirt_Clock_Offset"] = e["detent_skirt_clock_offset"]
+    g["Drive_Notch_Theta"] = e["drive_notch_theta"] + e["detent_skirt_clock_offset"]
+    g["Detent_Valley_To_Center"] = e["detent_valley_to_center"]
+
+    g["Floor"] = e["floor"]
+    g["Roof"] = g["Top_Flat_To_Center"] - g["Top_Flat_Thickness"]
+
+    layout = cfg["layout"]
+    g["Chars_Per_Row"] = layout["chars_per_row"]
+    g["Chars_Per_Row_Reference"] = layout["chars_per_row_reference"]
+    g["Longitude_Step"] = 360.0 / layout["chars_per_row"]
+    g["Row_Latitudes"] = layout["row_latitudes"]
+    g["Platen_Longitude_Offsets"] = layout["platen_longitude_offsets"]
+    g["Baseline_Longitude_Offsets"] = layout["baseline_longitude_offsets"]
+    g["Minkowski_Longitudinal_Offsets"] = layout["minkowski_longitudinal_offsets"]
+
+    lbl = cfg["label"]
+    g["Label"] = lbl["enabled"]
+    g["Arrow"] = lbl["arrow_enabled"]
+    g["Labels_Show_Number"] = lbl["show_number"]
+    g["Label_No"] = lbl["label_no"]
+    g["Label_Text_Override"] = lbl["label_text_override"]
+    g["Label_No_Font_Override"] = lbl["label_no_font_override"]
+    g["Label_Font_Override"] = lbl["label_font_override"]
+    g["No_Label_Size"] = lbl["no_label_size"]
+    g["No_Label_Offset"] = lbl["no_label_offset"]
+    g["Font_Label_Size"] = lbl["font_label_size"]
+    g["Font_Label_Offset"] = lbl["font_label_offset"]
+    g["Del_Base_From_Centre"] = lbl["del_base_from_centre"]
+    g["Del_Depth"] = lbl["del_depth"]
+
+    b = cfg["build"]
+    g["DEFAULT_POINTS_PER_MM"] = b["points_per_mm"]
+    g["Mink_Draft_Angle"] = b["draft_angle_deg"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["Mink_Cone_Height_Mm"] = b["mink_cone_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Surface_Fn"] = q["surface_fn"]
+    g["Cyl_Fn"] = q["cyl_fn"]
+    g["Mink_Fn"] = q["minkowski_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+    g["Tip_D"] = r["tip_od"]
+    g["Tip_Notch_D"] = r["tip_notch_od"]
+    g["Tip_Notch_Offset"] = r["tip_notch_offset"]
+    g["Tip_In"] = r["tip_in"]
+    g["Tip_H"] = r["tip_h"]
+    g["Rod_D"] = r["rod_od"]
+    g["Base_D"] = r["base_od"]
+    g["Base_H"] = r["base_h"]
+    g["Min_Rod_H"] = r["min_rod_h"]
+    g["Resin_Detent_Clock_Offset"] = r["resin_detent_clock_offset"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    tt = cfg.get("type_test", {})
+    g["Test_CPI"] = tt.get("cpi", 10.0)
+    g["Test_String_Custom"] = tt.get("text", "")
+
+    # Character/hemisphere layout - see lib/layouts/selectric12_layout.py
+    g["CASES88_LOWER"] = LOWERCASE88_US
+    g["CASES88_UPPER"] = UPPERCASE88_US
+    g["LONGITUDE_LATITUDE"] = longitude_latitude()
+
+    _configured = True
+    spherical_machine._receive_config(g, "selectric12")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call selectric12.configure(config_path) before using this module")

--- a/v4/lib/selectric3.py
+++ b/v4/lib/selectric3.py
@@ -1,0 +1,156 @@
+"""
+v4 Selectric III typeball - ports the Render_Mode==2 branch of
+v2/ibm.scad (+ v2/lib/layouts/ibm_layouts.scad's S3-specific section).
+
+All real-machine numbers live in config/selectric3.yaml, not here - call
+configure(path) once before using anything else in this module (see
+generate.py).
+
+Everything structurally shared with Selectric I/II/Selectric Composer
+(FullBody/SolidCleanup/Teeth/Notch/the character-glyph pipeline/labels/
+resin supports) lives in lib/spherical_machine.py - see that module's
+docstring for the dynamic-dispatch mechanism. Only the character/
+hemisphere layout data (lib/layouts/selectric3_layout.py, 96 chars/4 rows
+of 24 instead of Selectric I/II's 88/22) and this configure() are
+Selectric-III-specific; Selectric I/II and III share the CPI/monospaced
+TextGauge() type-test convention (in spherical_machine.py).
+"""
+
+import yaml
+
+import spherical_machine
+from spherical_machine import FullElement, ResinPrint, Additive, TextGauge  # re-exported for callers
+from layouts.selectric3_layout import LOWERCASE96_US, UPPERCASE96_US, longitude_latitude
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    g["Font_Size"] = font["size_mm"]
+    g["FONT_NAME"] = font["name"]
+
+    font2 = cfg["font2"]
+    g["FONT2_PATH"] = font2["font2_path"]
+    g["Font2_Size"] = font2["font2_size_mm"]
+    g["Font2_Chars"] = font2["font2_chars"]
+
+    align = cfg["alignment"]
+    g["H_Alignment"] = align["mode"]
+    g["X_Pos_Offset"] = align["x_pos_offset"]
+    g["Y_Pos_Offset"] = align["y_pos_offset"]
+    g["CUSTOMHALIGNCHARS"] = align["custom_h_chars"]
+    g["CUSTOMHALIGNOFFSET"] = align["custom_h_offset"]
+    g["CUSTOMVALIGNCHARS"] = align["custom_v_chars"]
+    g["CUSTOMVALIGNOFFSET"] = align["custom_v_offset"]
+
+    e = cfg["element"]
+    g["Sphere_OD"] = e["sphere_od"]
+    g["Sphere_R"] = e["sphere_od"] / 2.0
+    g["Max_OD"] = e["max_od"]
+    g["Type_Altitude"] = (e["max_od"] - e["sphere_od"]) / 2.0
+    g["Top_Flat_To_Center"] = e["top_flat_to_center"]
+    g["Top_Flat_Thickness"] = e["top_flat_thickness"]
+    g["Top_Flat_R"] = (g["Sphere_R"] ** 2 - e["top_flat_to_center"] ** 2) ** 0.5
+    g["Top_Chamfer"] = e["top_chamfer"]
+    g["Inside_ID"] = e["inside_id"]
+    g["Inside_R"] = e["inside_id"] / 2.0
+    g["Boss_OD"] = e["boss_od"]
+    g["Boss_R"] = e["boss_od"] / 2.0
+    g["Boss_Clearance"] = e["boss_clearance"]
+    g["Boss_Step"] = e["boss_step"]
+    g["Boss_To_Center"] = e["boss_to_center_base"] + e["snoot_droop_compensation"]
+    g["Snoot_Droop_Compensation"] = e["snoot_droop_compensation"]
+    g["Shaft_ID"] = e["shaft_id"]
+    g["Skirt_Top_OD"] = e["skirt_top_od"]
+    g["Skirt_Bottom_OD"] = e["skirt_bottom_od"]
+    skirt_top_r = e["skirt_top_od"] / 2.0
+    g["Center_To_Skirt"] = (g["Sphere_R"] ** 2 - skirt_top_r ** 2) ** 0.5
+    g["Platen_OD"] = e["platen_diameter"]
+    g["Drive_Notch_Width"] = e["drive_notch_width"]
+    g["Drive_Notch_Height"] = e["drive_notch_height"]
+    g["Detent_Skirt_Clock_Offset"] = e["detent_skirt_clock_offset"]
+    g["Drive_Notch_Theta"] = e["drive_notch_theta"] + e["detent_skirt_clock_offset"]
+    g["Detent_Valley_To_Center"] = e["detent_valley_to_center"]
+
+    g["Floor"] = e["floor"]
+    g["Roof"] = g["Top_Flat_To_Center"] - g["Top_Flat_Thickness"]
+
+    layout = cfg["layout"]
+    g["Chars_Per_Row"] = layout["chars_per_row"]
+    g["Chars_Per_Row_Reference"] = layout["chars_per_row_reference"]
+    g["Longitude_Step"] = 360.0 / layout["chars_per_row"]
+    g["Row_Latitudes"] = layout["row_latitudes"]
+    g["Platen_Longitude_Offsets"] = layout["platen_longitude_offsets"]
+    g["Baseline_Longitude_Offsets"] = layout["baseline_longitude_offsets"]
+    g["Minkowski_Longitudinal_Offsets"] = layout["minkowski_longitudinal_offsets"]
+
+    lbl = cfg["label"]
+    g["Label"] = lbl["enabled"]
+    g["Arrow"] = lbl["arrow_enabled"]
+    g["Labels_Show_Number"] = lbl["show_number"]
+    g["Label_No"] = lbl["label_no"]
+    g["Label_Text_Override"] = lbl["label_text_override"]
+    g["Label_No_Font_Override"] = lbl["label_no_font_override"]
+    g["Label_Font_Override"] = lbl["label_font_override"]
+    g["No_Label_Size"] = lbl["no_label_size"]
+    g["No_Label_Offset"] = lbl["no_label_offset"]
+    g["Font_Label_Size"] = lbl["font_label_size"]
+    g["Font_Label_Offset"] = lbl["font_label_offset"]
+    g["Del_Base_From_Centre"] = lbl["del_base_from_centre"]
+    g["Del_Depth"] = lbl["del_depth"]
+
+    b = cfg["build"]
+    g["DEFAULT_POINTS_PER_MM"] = b["points_per_mm"]
+    g["Mink_Draft_Angle"] = b["draft_angle_deg"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["Mink_Cone_Height_Mm"] = b["mink_cone_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Surface_Fn"] = q["surface_fn"]
+    g["Cyl_Fn"] = q["cyl_fn"]
+    g["Mink_Fn"] = q["minkowski_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+    g["Tip_D"] = r["tip_od"]
+    g["Tip_Notch_D"] = r["tip_notch_od"]
+    g["Tip_Notch_Offset"] = r["tip_notch_offset"]
+    g["Tip_In"] = r["tip_in"]
+    g["Tip_H"] = r["tip_h"]
+    g["Rod_D"] = r["rod_od"]
+    g["Base_D"] = r["base_od"]
+    g["Base_H"] = r["base_h"]
+    g["Min_Rod_H"] = r["min_rod_h"]
+    g["Resin_Detent_Clock_Offset"] = r["resin_detent_clock_offset"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    tt = cfg.get("type_test", {})
+    g["Test_CPI"] = tt.get("cpi", 10.0)
+    g["Test_String_Custom"] = tt.get("text", "")
+
+    # Character/hemisphere layout - see lib/layouts/selectric3_layout.py
+    g["CASES88_LOWER"] = LOWERCASE96_US
+    g["CASES88_UPPER"] = UPPERCASE96_US
+    g["LONGITUDE_LATITUDE"] = longitude_latitude()
+
+    _configured = True
+    spherical_machine._receive_config(g, "selectric3")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call selectric3.configure(config_path) before using this module")

--- a/v4/lib/selectric_composer.py
+++ b/v4/lib/selectric_composer.py
@@ -1,0 +1,164 @@
+"""
+v4 Selectric Composer typeball - ports the Render_Mode==0 branch of
+v2/ibm.scad (+ v2/lib/layouts/ibm_layouts.scad's Composer-specific
+section, US language only - see lib/layouts/selectric_composer_layout.py).
+
+All real-machine numbers live in config/selectric_composer.yaml, not
+here - call configure(path) once before using anything else in this
+module (see generate.py).
+
+Everything structurally shared with Selectric I/II/III (FullBody/
+SolidCleanup/Teeth/Notch/the character-glyph pipeline/labels/resin
+supports) lives in lib/spherical_machine.py - see that module's docstring
+for the dynamic-dispatch mechanism. Composer's own pica/units type-test
+system (v2's TextGaugeComposerLine2/Composer_Pitch_List/cumulativeSum) is
+NOT ported in this pass - genuinely different code from Selectric I/II &
+III's shared CPI TextGauge(), and not required for FullElement/
+ResinPrint (a separate print-test-gauge render variant) - deferred like
+Calibration/drain holes were for the other two Selectric machines.
+
+IMPORTANT: alignment.x_pos_offset/y_pos_offset/h_alignment/
+custom_h_offset/custom_v_offset in config/selectric_composer.yaml are
+print-critical per explicit user directive - verified line-by-line
+against v2/ibm.scad's X_Pos_Offset_Composer_/Y_Pos_Offset_Composer/
+All_H_Alignments[0], not approximated or defaulted from Selectric I/II's
+values despite sharing the same physical ball class.
+"""
+
+import yaml
+
+import spherical_machine
+from spherical_machine import FullElement, ResinPrint, Additive  # re-exported for callers
+from layouts.selectric_composer_layout import LOWERCASECOMPOSER_US, UPPERCASECOMPOSER_US, longitude_latitude
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    # v2: Font_Size_Selected = Composer_Cap_Height/2.834 (ibm.scad:186,190) -
+    # Composer's cap-height sizing convention, NOT Selectric I/II & III's
+    # direct point size.
+    g["Font_Size"] = font["composer_cap_height"] / 2.834
+    g["FONT_NAME"] = font["name"]
+
+    font2 = cfg["font2"]
+    g["FONT2_PATH"] = font2["font2_path"]
+    g["Font2_Size"] = font2["font2_composer_cap_height"] / 2.834
+    g["Font2_Chars"] = font2["font2_chars"]
+
+    align = cfg["alignment"]
+    g["H_Alignment"] = align["mode"]
+    g["X_Pos_Offset"] = align["x_pos_offset"]
+    g["Y_Pos_Offset"] = align["y_pos_offset"]
+    g["CUSTOMHALIGNCHARS"] = align["custom_h_chars"]
+    g["CUSTOMHALIGNOFFSET"] = align["custom_h_offset"]
+    g["CUSTOMVALIGNCHARS"] = align["custom_v_chars"]
+    g["CUSTOMVALIGNOFFSET"] = align["custom_v_offset"]
+
+    e = cfg["element"]
+    g["Sphere_OD"] = e["sphere_od"]
+    g["Sphere_R"] = e["sphere_od"] / 2.0
+    g["Max_OD"] = e["max_od"]
+    g["Type_Altitude"] = (e["max_od"] - e["sphere_od"]) / 2.0
+    g["Top_Flat_To_Center"] = e["top_flat_to_center"]
+    g["Top_Flat_Thickness"] = e["top_flat_thickness"]
+    g["Top_Flat_R"] = (g["Sphere_R"] ** 2 - e["top_flat_to_center"] ** 2) ** 0.5
+    g["Top_Chamfer"] = e["top_chamfer"]
+    g["Inside_ID"] = e["inside_id"]
+    g["Inside_R"] = e["inside_id"] / 2.0
+    g["Boss_OD"] = e["boss_od"]
+    g["Boss_R"] = e["boss_od"] / 2.0
+    g["Boss_Clearance"] = e["boss_clearance"]
+    g["Boss_Step"] = e["boss_step"]
+    g["Boss_To_Center"] = e["boss_to_center_base"] + e["snoot_droop_compensation"]
+    g["Snoot_Droop_Compensation"] = e["snoot_droop_compensation"]
+    g["Shaft_ID"] = e["shaft_id"]
+    g["Skirt_Top_OD"] = e["skirt_top_od"]
+    g["Skirt_Bottom_OD"] = e["skirt_bottom_od"]
+    skirt_top_r = e["skirt_top_od"] / 2.0
+    g["Center_To_Skirt"] = (g["Sphere_R"] ** 2 - skirt_top_r ** 2) ** 0.5
+    g["Platen_OD"] = e["platen_diameter"]
+    g["Drive_Notch_Width"] = e["drive_notch_width"]
+    g["Drive_Notch_Height"] = e["drive_notch_height"]
+    g["Detent_Skirt_Clock_Offset"] = e["detent_skirt_clock_offset"]
+    g["Drive_Notch_Theta"] = e["drive_notch_theta"] + e["detent_skirt_clock_offset"]
+    g["Detent_Valley_To_Center"] = e["detent_valley_to_center"]
+
+    g["Floor"] = e["floor"]
+    g["Roof"] = g["Top_Flat_To_Center"] - g["Top_Flat_Thickness"]
+
+    layout = cfg["layout"]
+    g["Chars_Per_Row"] = layout["chars_per_row"]
+    g["Chars_Per_Row_Reference"] = layout["chars_per_row_reference"]
+    g["Longitude_Step"] = 360.0 / layout["chars_per_row"]
+    g["Row_Latitudes"] = layout["row_latitudes"]
+    g["Platen_Longitude_Offsets"] = layout["platen_longitude_offsets"]
+    g["Baseline_Longitude_Offsets"] = layout["baseline_longitude_offsets"]
+    g["Minkowski_Longitudinal_Offsets"] = layout["minkowski_longitudinal_offsets"]
+
+    lbl = cfg["label"]
+    g["Label"] = lbl["enabled"]
+    g["Arrow"] = lbl["arrow_enabled"]
+    g["Labels_Show_Number"] = lbl["show_number"]
+    g["Label_No"] = lbl["label_no"]
+    g["Label_Text_Override"] = lbl["label_text_override"]
+    g["Label_No_Font_Override"] = lbl["label_no_font_override"]
+    g["Label_Font_Override"] = lbl["label_font_override"]
+    g["No_Label_Size"] = lbl["no_label_size"]
+    g["No_Label_Offset"] = lbl["no_label_offset"]
+    g["Font_Label_Size"] = lbl["font_label_size"]
+    g["Font_Label_Offset"] = lbl["font_label_offset"]
+    g["Del_Base_From_Centre"] = lbl["del_base_from_centre"]
+    g["Del_Depth"] = lbl["del_depth"]
+
+    b = cfg["build"]
+    g["DEFAULT_POINTS_PER_MM"] = b["points_per_mm"]
+    g["Mink_Draft_Angle"] = b["draft_angle_deg"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["Mink_Cone_Height_Mm"] = b["mink_cone_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Surface_Fn"] = q["surface_fn"]
+    g["Cyl_Fn"] = q["cyl_fn"]
+    g["Mink_Fn"] = q["minkowski_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+    g["Tip_D"] = r["tip_od"]
+    g["Tip_Notch_D"] = r["tip_notch_od"]
+    g["Tip_Notch_Offset"] = r["tip_notch_offset"]
+    g["Tip_In"] = r["tip_in"]
+    g["Tip_H"] = r["tip_h"]
+    g["Rod_D"] = r["rod_od"]
+    g["Base_D"] = r["base_od"]
+    g["Base_H"] = r["base_h"]
+    g["Min_Rod_H"] = r["min_rod_h"]
+    g["Resin_Detent_Clock_Offset"] = r["resin_detent_clock_offset"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    # Character/hemisphere layout - see lib/layouts/selectric_composer_layout.py
+    g["CASES88_LOWER"] = LOWERCASECOMPOSER_US
+    g["CASES88_UPPER"] = UPPERCASECOMPOSER_US
+    g["LONGITUDE_LATITUDE"] = longitude_latitude()
+
+    _configured = True
+    spherical_machine._receive_config(g, "selectric_composer")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call selectric_composer.configure(config_path) before using this module")

--- a/v4/lib/spherical_machine.py
+++ b/v4/lib/spherical_machine.py
@@ -1,0 +1,548 @@
+"""
+Shared spherical-typeball-family code (Selectric I/II, Selectric Composer,
+Selectric III) - the analogue of lib/cylinder_machine.py for this physical
+form factor, per CLAUDE.md's "Porting a new machine" taxonomy (IBM/
+Selectric is a different form factor from the cylinder family, sharing
+nothing with cylinder_machine.py - verified function-by-function against
+v2/ibm.scad + v2/lib/layouts/ibm_layouts.scad, not assumed).
+
+v2/ibm.scad models Composer/Selectric I-II/Selectric III as ONE file
+indexed by Render_Mode (0/1/2) into parallel arrays - not three separate
+designs. This module holds everything that's byte-identical across all
+three modes there (FullBody/SolidCleanup/Teeth/Notch/the character-glyph
+pipeline/labels/resin supports); the 3 real per-mode divergences
+(character/hemisphere layout data, font-size convention, type-test
+rendering) live one-per-machine in lib/selectric12.py / lib/
+selectric_composer.py / lib/selectric3.py, dynamically dispatched via
+_receive_config() exactly like cylinder_machine.py's own mechanism (see
+that module's docstring for the general scheme - safe here for the same
+reason: generate.py configures exactly one machine per process).
+
+Character-embedding order is NOT the same as glyph_poc.build_glyph()'s
+(draft-in-local-space, then place-on-cylinder): v2's SingleMinkowski
+POSITIONS the character in world coordinates FIRST (PositionText's real
+rotate/translate to its sphere longitude/latitude), THEN Minkowski-sums
+with a draft cone built at the ORIGIN (only rotated, never translated).
+This is still correct: a Minkowski sum with a small compact shape B is a
+purely LOCAL dilation of A by B's own point-set, regardless of where B's
+centroid sits in world space - B's points are literally the offset
+vectors added to every point of A. Verified by hand against v2's exact
+transform stack (rotate/translate order) before writing this, not
+assumed compatible with build_glyph's own (different) construction -
+build_glyph's cylinder-family-specific PlatenCutout model does NOT
+directly generalize to the sphere's PlatenCutout (different transform
+composition - PlatenCutout here is built via its OWN rotate/translate
+stack sharing longitude/latitude with the character, not expressed
+relative to the character's local frame the way build_glyph assumes), so
+this module reimplements Text()/PositionText()/PlatenCutout()/
+SingleMinkowski() as a direct, literal port instead of reusing build_glyph.
+
+Not yet ported (all default OFF/0 in v2, so this doesn't change default
+behavior - explicit callouts per CLAUDE.md's "say so, don't silently
+diverge" convention): Font_Weight_Offset/X_Weight_Adjustment/
+Y_Weight_Adjustment (Text()'s 2D minkowski-with-square weight adjustment),
+Mink_Flat (a debug duplicate flat-preview copy), Rays()/Selective_Render
+(dev-only visualization), Drain (the "[Experimental Drain Holes]"
+feature), ConsoleCutout()'s echo (Cutout_Test/Draft_Angle_Test/
+Mink_Long_Offset_Test/Platen_Diameter_Test console diagnostics - the
+underlying per-row Platen_Longitude_Offsets/Minkowski_Longitudinal_Offsets/
+Baseline_Longitude_Offsets tuning ARE ported, just not the sweep-test
+console output), CalibrationElement/CalibrationAdditive (deferred to a
+follow-up pass).
+"""
+
+import numpy as np
+import trimesh
+import freetype
+from manifold3d import Manifold, Mesh as ManifoldMesh
+
+from glyph_poc import get_glyph_contours_and_advance, classify_and_triangulate, alignment_x_offset
+import scad_primitives as sp
+import resin_support
+
+_active_machine = None
+
+
+def _receive_config(source_globals, machine_name):
+    global _active_machine
+    if _active_machine not in (None, machine_name):
+        raise RuntimeError(
+            f"spherical_machine already configured for {_active_machine!r}; "
+            f"cannot reconfigure for {machine_name!r} in the same process")
+    _active_machine = machine_name
+    globals().update({k: v for k, v in source_globals.items() if k[:1].isupper() or k == "z"})
+
+
+def _require_configured():
+    if _active_machine is None:
+        raise RuntimeError("call <machine>.configure(config_path) before using this module")
+
+
+def _to_manifold(mesh):
+    return Manifold(mesh=ManifoldMesh(
+        vert_properties=np.array(mesh.vertices, dtype=np.float32),
+        tri_verts=np.array(mesh.faces, dtype=np.uint32)))
+
+
+def _from_manifold(manifold):
+    m = manifold.to_mesh()
+    return trimesh.Trimesh(vertices=m.vert_properties, faces=m.tri_verts, process=False)
+
+
+# --------------------------------------------------------------- Body/Sphere
+
+def FullBody(points_per_mm=None, minkowski_enabled=None, draft_angle_deg=None):
+    """FullBody() (v2/ibm.scad:486-494): union(sphere, skirt frustum,
+    AssembleMinkowski())."""
+    _require_configured()
+    ball = trimesh.creation.icosphere(subdivisions=4, radius=Sphere_OD / 2.0)
+    skirt = sp.frustum_z(Skirt_Bottom_OD, Skirt_Top_OD, Floor - Center_To_Skirt,
+                          sections=Surface_Fn, base_z=-Floor)
+    ring = AssembleMinkowski(points_per_mm=points_per_mm, minkowski_enabled=minkowski_enabled,
+                              draft_angle_deg=draft_angle_deg)
+    return sp.union_all([ball, skirt, ring])
+
+
+# ------------------------------------------------------- Character embedding
+
+def _text2d_contours(char, font_path, font_size_mm, points_per_mm, halign,
+                      x_pos_offset, y_pos_offset, custom_h_offset, custom_v_offset):
+    """Text() (v2/ibm.scad:497-507) - 2D glyph outline in mm, with v2's
+    exact halign -> mirror -> translate order (NOT build_glyph's own
+    shift-then-mirror convention - see module docstring). Weight
+    adjustment (Font_Weight_Offset/X_Weight_Adjustment/Y_Weight_Adjustment)
+    not implemented - see module docstring."""
+    face = freetype.Face(font_path)
+    scale = font_size_mm / face.units_per_EM
+    contours_font_units, advance_mm = get_glyph_contours_and_advance(
+        char, points_per_mm, scale, font_path=font_path)
+    contours_mm = [c * scale for c in contours_font_units]
+    # OpenSCAD text()'s own halign, applied INSIDE text() before Text()'s
+    # mirror/translate wrapper - alignment_x_offset with no extra
+    # offset params reproduces exactly this (center: -advance/2, left: 0).
+    halign_shift = alignment_x_offset(char, advance_mm, mode=halign)
+    contours_mm = [c + np.array([halign_shift, 0.0]) for c in contours_mm]
+    # mirror([1, 0, 0])
+    contours_mm = [c * np.array([-1.0, 1.0]) for c in contours_mm]
+    # translate([X_Pos_Offset-customhalign, Y_Pos_Offset+customvalign, 0])
+    contours_mm = [c + np.array([x_pos_offset - custom_h_offset, y_pos_offset + custom_v_offset])
+                   for c in contours_mm]
+    return contours_mm
+
+
+def SingleMinkowskiChar(char, longitude, latitude, plat_offset, base_offset,
+                        minklongoffset, draft_angle, platendia, font_path, font_size_mm,
+                        custom_h_offset=0.0, custom_v_offset=0.0,
+                        points_per_mm=None, minkowski_enabled=None):
+    """SingleMinkowski() (v2/ibm.scad:553-587) - one struck character:
+    build the 2D glyph, extrude to a flat block, carve the platen scallop
+    (a real cylinder, matching PlatenCutout()'s own construction exactly -
+    NOT build_glyph's cylinder-family model, see module docstring), then
+    Minkowski-sum with a draft cone. Mink_Flat's extra flat-preview copy
+    is not ported (debug-only, defaults off)."""
+    _require_configured()
+    points_per_mm = DEFAULT_POINTS_PER_MM if points_per_mm is None else points_per_mm
+    minkowski_enabled = DEFAULT_MINKOWSKI_ENABLED if minkowski_enabled is None else minkowski_enabled
+    contours_mm = _text2d_contours(char, font_path, font_size_mm, points_per_mm,
+                                    H_Alignment, X_Pos_Offset, Y_Pos_Offset,
+                                    custom_h_offset, custom_v_offset)
+    flat = classify_and_triangulate(contours_mm)
+    if flat is None:
+        return None  # matches v2 rendering an empty/invisible character (e.g. space)
+
+    prism = trimesh.creation.extrude_triangulation(flat.vertices[:, :2], flat.faces,
+                                                    Character_Block_Height_Mm)
+
+    # PositionText(longitude, latitude+base_offset): rotate([90-latitude,0,
+    # 90+longitude]); translate([0,0,Sphere_R+z]) - source top-to-bottom
+    # order, matching sp.scad_transform's documented convention.
+    eff_latitude = latitude + base_offset
+    positioned = sp.scad_transform(
+        prism,
+        ("rotate", [90 - eff_latitude, 0, 90 + longitude]),
+        ("translate", [0, 0, Sphere_R + z]),
+    )
+
+    # PlatenCutout(longitude, latitude+plat_offset, platendia)
+    # (v2/ibm.scad:510-516) - built via its OWN transform stack (source
+    # top-to-bottom: rotate([0,-latitude,longitude]); translate([Sphere_R+
+    # platenr+Type_Altitude,0,0]); rotate([90,0,0])), sharing the SAME
+    # longitude/latitude+plat_offset as the character above but NOT
+    # expressed relative to the character's own local frame.
+    platenr = platendia / 2.0
+    cutter = trimesh.creation.cylinder(radius=platenr, height=10.0, sections=Cyl_Fn)
+    eff_plat_latitude = latitude + plat_offset
+    cutter = sp.scad_transform(
+        cutter,
+        ("rotate", [0, -eff_plat_latitude, longitude]),
+        ("translate", [Sphere_R + platenr + Type_Altitude, 0, 0]),
+        ("rotate", [90, 0, 0]),
+    )
+    scalloped = positioned.difference(cutter, engine="manifold")
+
+    if not minkowski_enabled:
+        return scalloped
+
+    # Minkowski draft cone(s), built at the ORIGIN (rotated only, never
+    # translated) - see module docstring for why this is still a correct
+    # local dilation of the already-positioned `scalloped` solid. Uses
+    # v2's own MINK_TEXT_R(draft_angle)=2*tan(.5*draft_angle) formula - a
+    # FIXED-height (Mink_Cone_Height_Mm) cone, unlike build_glyph's
+    # separation_mm-scaled cone - a real, intentional difference in the
+    # v2 source (see spherical_machine's module docstring), not something
+    # to reconcile with the cylinder family's formula.
+    mink_r = 2.0 * np.tan(np.radians(draft_angle / 2.0))
+    cone1 = Manifold.cylinder(Mink_Cone_Height_Mm, mink_r, 0.0, circular_segments=Mink_Fn)
+    cone1 = cone1.translate([0, 0, -Mink_Cone_Height_Mm])
+    if minklongoffset != 0:
+        cone2 = cone1.rotate([-minklongoffset, 0, 0])
+        cone_hull = trimesh.util.concatenate(
+            [_from_manifold(cone1), _from_manifold(cone2)]).convex_hull
+    else:
+        cone_hull = _from_manifold(cone1)
+    # rotate([90-latitude,0,90+longitude]) - the SAME rotation PositionText
+    # used, but on the RAW latitude (no base_offset) - matches v2 exactly,
+    # not "fixed" to match the character's own base_offset-adjusted latitude.
+    cone_hull = sp.scad_transform(cone_hull, ("rotate", [90 - latitude, 0, 90 + longitude]))
+
+    drafted = _to_manifold(scalloped).minkowski_sum(_to_manifold(cone_hull))
+    return _from_manifold(drafted)
+
+
+def AssembleMinkowski(points_per_mm=None, minkowski_enabled=None, draft_angle_deg=None):
+    """AssembleMinkowski() (v2/ibm.scad:618-655) - places every character
+    of both cases (lowercase=0, uppercase=1, 180 degrees apart) at its
+    real hemisphere position. LONGITUDE_LATITUDE/CASES88 are supplied by
+    the calling machine module's configure() (CASES88_LOWER/CASES88_UPPER/
+    LONGITUDE_LATITUDE globals) - see lib/layouts/selectric12_layout.py
+    for how these are derived. Selective_Render/Rays not ported (dev-only,
+    default off - see module docstring)."""
+    _require_configured()
+    draft_angle_deg = Mink_Draft_Angle if draft_angle_deg is None else draft_angle_deg
+    parts = []
+    for case_int in (0, 1):
+        case_str = CASES88_LOWER if case_int == 0 else CASES88_UPPER
+        for longitude_col, latitude_row, _kb_char, kb_index in LONGITUDE_LATITUDE:
+            char = case_str[kb_index]
+            longitude = longitude_col * Longitude_Step + case_int * 180
+            latitude = Row_Latitudes[latitude_row]
+            plat_offset = Platen_Longitude_Offsets[latitude_row]
+            base_offset = Baseline_Longitude_Offsets[latitude_row]
+            minklongoffset = Minkowski_Longitudinal_Offsets[latitude_row]
+            font_path = FONT2_PATH if char in Font2_Chars else FONT_PATH
+            font_size = Font2_Size if char in Font2_Chars else Font_Size
+            custom_h = CUSTOMHALIGNOFFSET if char in CUSTOMHALIGNCHARS else 0.0
+            custom_v = CUSTOMVALIGNOFFSET if char in CUSTOMVALIGNCHARS else 0.0
+            mesh = SingleMinkowskiChar(char, longitude, latitude, plat_offset, base_offset,
+                                       minklongoffset, draft_angle_deg, Platen_OD,
+                                       font_path, font_size, custom_h, custom_v,
+                                       points_per_mm=points_per_mm, minkowski_enabled=minkowski_enabled)
+            if mesh is not None:
+                parts.append(mesh)
+    print(f"AssembleMinkowski: built {len(parts)} characters", flush=True)
+    return sp.union_all(parts)
+
+
+# -------------------------------------------------------------- Subtractive
+
+def HollowProfile3():
+    """HollowProfile3() (v2/ibm.scad:692-708) - a hull() of 3 circles plus
+    a square, unioned with a second plain square, revolved. Built as a
+    real shapely hull (matching WireBite()'s pattern in
+    cylinder_machine.py) rather than a hand-derived polygon, then
+    converted to a rotate_extrude profile."""
+    from shapely.geometry import Point, box as shapely_box
+    from shapely.ops import unary_union
+    newroofr = 1.0
+    c1 = Point(-newroofr + Inside_R, Boss_To_Center + Boss_Clearance).buffer(newroofr, resolution=32)
+    # v2: translate([Boss_R+Boss_Step,0,0]) square([Inside_R-Boss_R-Boss_Step, 1])
+    # - a wide, short rectangle from x=Boss_R+Boss_Step to x=Inside_R at
+    # y=[0,1] - NOT a 1x(Boss_To_Center+Boss_Clearance) strip (an earlier,
+    # wrong transcription of this hull component - fixed after it produced
+    # a visibly malformed hollow-cavity wall).
+    sq = shapely_box(Boss_R + Boss_Step, 0, Inside_R, 1.0)
+    c2 = Point(Boss_R + newroofr + Boss_Step, Boss_To_Center + Boss_Clearance).buffer(newroofr, resolution=32)
+    c3 = Point((Inside_R + Boss_R + Boss_Step) / 2,
+               Top_Flat_To_Center - Top_Flat_Thickness - newroofr).buffer(newroofr, resolution=32)
+    hull_poly = unary_union([c1, sq, c2, c3]).convex_hull
+    extra_sq = shapely_box(Boss_R, 0, Boss_R + Boss_Step + z, Boss_To_Center + Boss_Clearance)
+    profile_poly = unary_union([hull_poly, extra_sq])
+    # rotate_extrude(polygon) sweeps X=radius, Y=Z - extract the exterior
+    # ring as an (r, z) point loop for sp.revolve_polygon.
+    coords = list(profile_poly.exterior.coords)
+    return sp.revolve_polygon(coords, sections=Surface_Fn)
+
+
+def Tooth():
+    """Tooth() (v2/ibm.scad:715-724) - detent tooth profile, scaled in Y
+    by Chars_Per_Row_S12/Chars_Per_Row (1.0 for Selectric I/II itself -
+    the scale exists so this SAME profile narrows correctly for a machine
+    with more teeth per row, e.g. Selectric III's 24)."""
+    from shapely.geometry import Polygon as ShapelyPolygon
+    scale_y = Chars_Per_Row_Reference / Chars_Per_Row
+    poly = np.array([[0, 1.9], [2.2, 0.4], [3.2, 0.14], [3.2, -0.14], [2.2, -0.4], [0, -1.9]])
+    mesh = trimesh.creation.extrude_polygon(ShapelyPolygon(poly), 30.0)
+    mesh.vertices[:, 1] *= scale_y
+    # translate([0,Detent_Valley_To_Center,-Floor-z]) rotate([180,-90,0])
+    return sp.scad_transform(
+        mesh,
+        ("translate", [0, Detent_Valley_To_Center, -Floor - z]),
+        ("rotate", [180, -90, 0]),
+    )
+
+
+def Teeth():
+    """Teeth() (v2/ibm.scad:728-732) - one Tooth() per character index
+    position around the ring."""
+    parts = [sp.rotate_z(Tooth(), i * Longitude_Step) for i in range(Chars_Per_Row)]
+    return sp.union_all(parts)
+
+
+def Notch():
+    """Notch() (v2/ibm.scad:735-739) - the drive notch cube."""
+    box = trimesh.creation.box(extents=[4.0, Drive_Notch_Width, Drive_Notch_Height + Snoot_Droop_Compensation + z])
+    box = sp.translate(box, [Shaft_ID / 2 - 0.5 + 2.0, 0, Boss_To_Center - z + (Drive_Notch_Height + Snoot_Droop_Compensation + z) / 2])
+    return sp.rotate_z(box, Drive_Notch_Theta)
+
+
+def Del():
+    """Del() (v2/ibm.scad:964-970) - the alignment-marker triangle
+    engraved into the top face. Color dropped (v4 has no color concept -
+    engraving is done via boolean subtraction, not appearance)."""
+    from shapely.geometry import Polygon as ShapelyPolygon
+    poly = ShapelyPolygon([[3.4, 0], [0.4, 1.3], [0.4, -1.3]])
+    mesh = trimesh.creation.extrude_polygon(poly, Del_Depth + z)
+    return sp.translate(mesh, [Del_Base_From_Centre, 0, Top_Flat_To_Center - Del_Depth])
+
+
+def Labels():
+    """Labels() (v2/ibm.scad:984-996) - the number label (disabled for
+    Composer - Render_Mode!=0 in v2; Selectric I/II and III both always
+    show it, see Labels_Show_Number below, set true by both) plus the
+    typeface label."""
+    from glyph_poc import build_flat_text
+    parts = []
+    if Labels_Show_Number:
+        no_font = Label_No_Font_Override or FONT_PATH
+        # v2 renders the whole Label_No STRING; build_flat_text is per-char -
+        # concatenate left-to-right at natural FreeType advance, same
+        # convention as cylinder_machine.build_text_string.
+        cursor = 0.0
+        no_parts = []
+        face = freetype.Face(no_font)
+        scale = No_Label_Size / face.units_per_EM
+        for ch in Label_No:
+            _, adv = get_glyph_contours_and_advance(ch, DEFAULT_POINTS_PER_MM, scale, font_path=no_font)
+            m = build_flat_text(ch, DEFAULT_POINTS_PER_MM, 0.01, font_size_mm=No_Label_Size, font_path=no_font)
+            no_parts.append(sp.translate(m, [cursor, 0, 0]))
+            cursor += adv
+        no_mesh = sp.translate(sp.union_all(no_parts), [-cursor / 2.0, 0, 0])
+        no_mesh = sp.translate(no_mesh, [-0.1 + No_Label_Offset, 14, 0])
+        parts.append(no_mesh)
+
+    label_font = Label_Font_Override or FONT_PATH
+    label_text = Label_Text_Override or FONT_NAME
+    cursor = 0.0
+    label_parts = []
+    face = freetype.Face(label_font)
+    scale = Font_Label_Size / face.units_per_EM
+    for ch in label_text:
+        if ch == " ":
+            cursor += Font_Label_Size * 0.3
+            continue
+        _, adv = get_glyph_contours_and_advance(ch, DEFAULT_POINTS_PER_MM, scale, font_path=label_font)
+        m = build_flat_text(ch, DEFAULT_POINTS_PER_MM, 0.01, font_size_mm=Font_Label_Size, font_path=label_font)
+        label_parts.append(sp.translate(m, [cursor, 0, 0]))
+        cursor += adv
+    label_mesh = sp.translate(sp.union_all(label_parts), [-cursor / 2.0, 0, 0])
+    label_mesh = sp.translate(label_mesh, [0, 0.6 + Font_Label_Offset, 0])
+    parts.append(label_mesh)
+    return sp.union_all(parts)
+
+
+def FontName():
+    """FontName() (v2/ibm.scad:973-981) - embosses Labels() onto the top
+    face."""
+    labels = Labels()
+    labels = sp.translate(labels, [0, 0, 0.01])  # lift the flat text off z=0 before positioning
+    return sp.scad_transform(
+        labels,
+        ("translate", [-8.5, 0, Top_Flat_To_Center - Del_Depth]),
+        ("rotate", [0, 0, 270]),
+    )
+
+
+def SolidCleanup():
+    """SolidCleanup() (v2/ibm.scad:661-689) - everything subtracted from
+    FullBody(). Drain not ported (defaults off - see module docstring)."""
+    parts = [
+        sp.translate(sp.cylinder_z(2 * (Top_Flat_R + 2), 10.0, sections=Surface_Fn),
+                     [0, 0, Top_Flat_To_Center]),
+        sp.cylinder_z(Shaft_ID, 40.0, sections=Cyl_Fn, center=True),
+        sp.translate(sp.frustum_z(Shaft_ID, Shaft_ID + 2 * Top_Chamfer, Top_Chamfer, sections=Surface_Fn),
+                     [0, 0, Top_Flat_To_Center - Top_Chamfer]),
+        sp.translate(sp.cylinder_z(Inside_ID, 20.0 + Boss_To_Center, sections=Surface_Fn), [0, 0, -20.0]),
+        HollowProfile3(),
+        Notch(),
+        sp.rotate_z(Teeth(), Detent_Skirt_Clock_Offset),
+    ]
+    if Arrow:
+        parts.append(Del())
+    if Label:
+        parts.append(FontName())
+    return sp.union_all(parts)
+
+
+def SubtractFromFull(points_per_mm=None, minkowski_enabled=None, draft_angle_deg=None):
+    full = FullBody(points_per_mm=points_per_mm, minkowski_enabled=minkowski_enabled,
+                    draft_angle_deg=draft_angle_deg)
+    clean = SolidCleanup()
+    result = full.difference(clean, engine="manifold")
+    result, _, _, _ = sp.check_and_repair(result, label="SubtractFromFull")
+    return result
+
+
+# ------------------------------------------------------------- Resin support
+# ResinRodAssemble() (v2/ibm.scad:790-878) - every real call site in the
+# current v2 file uses a1=0 (the angle-tilted-tip variants are commented
+# out dead code) - so this ports as straight vertical rods via
+# resin_support.resin_rod()/connecting_rod() (the shared, already-generic
+# rod/strut primitives every other machine's resin support uses), not a
+# bespoke angle-aware system. a1 is therefore NOT a parameter here - a
+# dead parameter in the real v2 source, not silently dropped (see module
+# docstring's convention).
+
+def _rod(h, tip_od):
+    return resin_support.resin_rod(h, tip_od, Tip_H, Rod_D, Tip_In, Min_Rod_H,
+                                    Base_H, Base_D, add_raft=True, resin_fn=Resin_Fn)
+
+
+def ResinRodAssemble():
+    _require_configured()
+    parts = []
+    for i in range(Chars_Per_Row):
+        rod = sp.translate(_rod(0.0, Tip_D), [(Skirt_Bottom_OD + Inside_ID) / 4, 0, 0])
+        parts.append(sp.rotate_z(rod, i * Longitude_Step + Detent_Skirt_Clock_Offset + Resin_Detent_Clock_Offset))
+
+    for i in range(11):
+        # roof-roof support-supports
+        p1 = np.array([(Boss_R + Inside_R + Boss_Step) / 2, 0, 6])
+        angle2 = np.radians(360 / 11)
+        p2 = np.array([(Boss_R + Inside_R + Boss_Step) / 2 * np.cos(angle2),
+                        (Boss_R + Inside_R + Boss_Step) / 2 * np.sin(angle2), 0])
+        hull1 = resin_support.connecting_rod(p1, p2, Rod_D)
+        parts.append(sp.rotate_z(hull1, i * 360 / 11))
+
+        if i != 4:
+            inner_x = (Boss_R + Shaft_ID / 2) / 2
+            parts.append(sp.rotate_z(sp.translate(_rod(Floor + Boss_To_Center, Tip_D), [inner_x, 0, 0]),
+                                      i * 360 / 11))
+            hull2 = resin_support.connecting_rod(
+                [inner_x, 0, 12], [(Boss_R + Inside_R + Boss_Step) / 2, 0, 8], Rod_D)
+            parts.append(sp.rotate_z(hull2, i * 360 / 11))
+            if i != 3:
+                x_offset = inner_x  # ResinXOffset(0) == 0
+                a2 = np.radians(360 / 11)
+                hull3 = resin_support.connecting_rod([x_offset, 0, 1],
+                                                       [x_offset * np.cos(a2), x_offset * np.sin(a2), 7], Rod_D)
+                parts.append(sp.rotate_z(hull3, i * 360 / 11))
+
+        parts.append(sp.rotate_z(sp.translate(_rod(Floor + Roof, Tip_D),
+                                               [(Boss_R + Inside_R + Boss_Step) / 2, 0, 0]),
+                                  i * 360 / 11))
+
+    n = Tip_Notch_Offset
+    inner_x = (Boss_R + Shaft_ID / 2) / 2
+    for j, k in enumerate([n, -n]):
+        parts.append(sp.rotate_z(sp.translate(_rod(Floor + Boss_To_Center, Tip_Notch_D), [inner_x, 0, 0]),
+                                  Drive_Notch_Theta + k))
+        # v2's hull() here rotates its TWO spheres by two DIFFERENT
+        # angles each (Drive_Notch_Theta-k[j] and l[j]*360/11), computed
+        # independently in world coordinates - not a single shared
+        # rotation applied to the whole hull afterward like the other
+        # strut cases above. A sphere is rotationally symmetric, so
+        # "translate then rotate the sphere" reduces to just placing it
+        # directly at the rotated point - computed that way here.
+        l = [3, 5][j]
+        theta1 = np.radians(Drive_Notch_Theta - k)
+        theta2 = np.radians(l * 360 / 11)
+        p1 = [inner_x * np.cos(theta1), inner_x * np.sin(theta1), 12]
+        p2 = [inner_x * np.cos(theta2), inner_x * np.sin(theta2), 7]
+        parts.append(resin_support.connecting_rod(p1, p2, Rod_D))
+    return sp.union_all(parts)
+
+
+# ------------------------------------------------------------------ Element
+
+def FullElement(points_per_mm=None, separation_mm=None, render_core_groove=None,
+                cone_segments=None, simplify_tolerance_mm=None, platen_fn=None,
+                minkowski_enabled=None, draft_angle_deg=None):
+    """separation_mm/render_core_groove/cone_segments/simplify_tolerance_mm/
+    platen_fn are accepted-but-ignored - generate.py's build_fn(...) call
+    is uniform across every machine (see CLAUDE.md's "Porting a new
+    machine" convention); Selectric has no core-groove concept, no
+    separate Minkowski-cone circular-segments knob (Mink_Fn from config
+    is used directly - see quality.minkowski_fn), and reuses Cyl_Fn for
+    the platen cutter's own facet count (matching v2, which has no
+    distinct Platen_Fn variable either - PlatenCutout's cylinder uses
+    Cyl_Fn directly, ibm.scad:515)."""
+    _require_configured()
+    result = SubtractFromFull(points_per_mm=points_per_mm, minkowski_enabled=minkowski_enabled,
+                              draft_angle_deg=draft_angle_deg)
+    print(f"FullElement: verts={len(result.vertices)} faces={len(result.faces)} "
+          f"watertight={result.is_watertight}", flush=True)
+    return result, []
+
+
+def Additive(points_per_mm=None, separation_mm=None, render_core_groove=None,
+             cone_segments=None, simplify_tolerance_mm=None, platen_fn=None,
+             minkowski_enabled=None, draft_angle_deg=None):
+    """No separate additive/subtractive split in the real geometry (unlike
+    the cylinder family) - FullBody() is a real union then FullBody minus
+    SolidCleanup happens together in SubtractFromFull(). Provided for
+    generate.py's uniform dispatch only - see FullElement's docstring for
+    the accepted-but-ignored kwargs."""
+    _require_configured()
+    return FullBody(points_per_mm=points_per_mm, minkowski_enabled=minkowski_enabled,
+                    draft_angle_deg=draft_angle_deg), []
+
+
+def ResinPrint(points_per_mm=None, separation_mm=None, render_core_groove=None,
+               cone_segments=None, simplify_tolerance_mm=None, platen_fn=None,
+               minkowski_enabled=None, draft_angle_deg=None):
+    _require_configured()
+    full, char_parts = FullElement(points_per_mm=points_per_mm, minkowski_enabled=minkowski_enabled,
+                                    draft_angle_deg=draft_angle_deg)
+    # v2's ResinPrint() (ibm.scad:881-887): `translate([0,0,Floor])
+    # SubtractFromFull(); ResinRodAssemble();` - the main body is shifted
+    # up by Floor so the detent teeth land at world z=0, which is the
+    # frame EVERY rod height in ResinRodAssemble() assumes (h=0 for teeth
+    # supports, Floor+Boss_To_Center for boss supports, Floor+Roof for
+    # roof supports - all measured from that same teeth-at-z=0 origin,
+    # not the sphere center FullElement() itself is built around). Missing
+    # this translate is exactly what put the rods at the wrong heights
+    # relative to the body - confirmed visually (rods floating detached
+    # from the ball) before this fix.
+    full = sp.translate(full, [0, 0, Floor])
+    support = ResinRodAssemble()
+    print(f"ResinSupport: verts={len(support.vertices)} faces={len(support.faces)} "
+          f"watertight={support.is_watertight}", flush=True)
+    combined = sp.union_all([full, support])
+    combined, _, _, _ = sp.check_and_repair(combined, label="ResinPrint")
+    return combined, char_parts
+
+
+# --------------------------------------------------------------- Type Test
+
+def TextGauge(text, cpi):
+    """TextGauge() (v2/ibm.scad:890-900) - monospaced CPI type-test gauge,
+    shared by Selectric I/II and Selectric III (Composer uses its own
+    pica-based system - lib/selectric_composer.py)."""
+    from glyph_poc import build_flat_text
+    parts = []
+    for i, ch in enumerate(text):
+        if ch == " ":
+            continue
+        m = build_flat_text(ch, DEFAULT_POINTS_PER_MM, 0.4, font_size_mm=Font_Size, font_path=FONT_PATH)
+        parts.append(sp.translate(m, [8 + i * 22.0 / cpi, 8, 0]))
+    return sp.union_all(parts)

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -190,6 +190,9 @@ MACHINES = {
     "bennett": ("Bennett", os.path.join(REPO_ROOT, "config", "bennett.yaml")),
     "helios": ("Helios Klimax", os.path.join(REPO_ROOT, "config", "helios.yaml")),
     "hammond": ("Hammond", os.path.join(REPO_ROOT, "config", "hammond.yaml")),
+    "selectric12": ("Selectric I/II", os.path.join(REPO_ROOT, "config", "selectric12.yaml")),
+    "selectric3": ("Selectric III", os.path.join(REPO_ROOT, "config", "selectric3.yaml")),
+    "selectric_composer": ("Selectric Composer", os.path.join(REPO_ROOT, "config", "selectric_composer.yaml")),
 }
 
 FONT_FILE_FILTERS = Filters(
@@ -745,6 +748,134 @@ ELEMENT_FIELDS_HAMMOND = [
     ("support_groove_thickness", ["element", "support_groove_thickness"], float, "Resin chamfer thickness (mm)", "Only used when groove is on."),
 ]
 
+# Selectric I/II, Selectric III, and Selectric Composer (spherical
+# typeball family, see lib/spherical_machine.py) share the EXACT SAME
+# config schema across all three machines (unlike Bennett/Mignon/Helios,
+# which each diverge structurally) - so one shared field-table set covers
+# all three, except Font & Alignment: Composer sizes type by cap-height
+# (font.composer_cap_height) instead of direct point size (font.size_mm),
+# so it gets its own table. No Logo/Gauge/Layout/Calibration tabs for any
+# of the three - no engraved logo text, no Shaft Gauge Test, no editable
+# keyboard-layout concept (the hemisphere character map is fixed, not a
+# user-selectable preset - see lib/layouts/selectric12_layout.py), and no
+# Calibration entry points implemented yet (CalibrationElement/
+# CalibrationAdditive - see lib/spherical_machine.py's module docstring's
+# "not yet ported" list) - compose()/_compose_build_tab gate the
+# Calibration tab/Build-target option on "Calibration" in self.SECTIONS,
+# and self.HAS_LAYOUT_TAB (set in _load_machine) gates the Layout tab and
+# every baseline_row/cutout_row-style widget, same pattern as the "Gauge"
+# key already used for machines with no Shaft Gauge Test.
+FONT_FIELDS_SELECTRIC12 = [
+    ("path", ["font", "path"], str, "Font path", "TrueType font for the struck characters."),
+    ("size_mm", ["font", "size_mm"], float, "Font size (mm)", "Direct point size (v2 Font_Size), not Composer's cap-height convention."),
+    ("font2_path", ["font2", "font2_path"], str, "Font 2 path", "Secondary font for font2_chars below."),
+    ("font2_size_mm", ["font2", "font2_size_mm"], float, "Font 2 size (mm)", ""),
+    ("font2_chars", ["font2", "font2_chars"], str, "Font 2 chars", "Characters that use font2 instead of font."),
+    ("mode", ["alignment", "mode"], str, "Align mode", '"center" or "left" (v2 H_Alignment).'),
+    ("x_pos_offset", ["alignment", "x_pos_offset"], float, "X position offset (mm)", "v2 X_Pos_Offset."),
+    ("y_pos_offset", ["alignment", "y_pos_offset"], float, "Y position offset (mm)", "v2 Y_Pos_Offset."),
+    ("custom_h_chars", ["alignment", "custom_h_chars"], str, "Custom H-align chars", "Get an extra horizontal offset (below)."),
+    ("custom_h_offset", ["alignment", "custom_h_offset"], float, "Custom H-align offset (mm)", ""),
+    ("custom_v_chars", ["alignment", "custom_v_chars"], str, "Custom V-align chars", "Get an extra vertical offset (below)."),
+    ("custom_v_offset", ["alignment", "custom_v_offset"], float, "Custom V-align offset (mm)", ""),
+    ("draft_angle_deg", ["build", "draft_angle_deg"], float, "Draft angle (deg)",
+     "Half-angle of the Minkowski draft cone each character is swept with. Real value 55."),
+]
+
+# Composer-only: sizes type by CAP HEIGHT (font.composer_cap_height/2.834
+# = Font_Size_Selected, v2's own fixed conversion, ibm.scad:186,190) - not
+# direct point size like Selectric I/II & III. custom_h_chars is
+# especially print-critical here - see config/selectric_composer.yaml's
+# header comment (explicit user directive on alignment fidelity).
+FONT_FIELDS_SELECTRIC_COMPOSER = [
+    ("path", ["font", "path"], str, "Font path", "TrueType font for the struck characters."),
+    ("composer_cap_height", ["font", "composer_cap_height"], float, "Cap height (pt)",
+     "v2 Composer_Cap_Height - Font_Size_Selected = this/2.834, not a direct point size."),
+    ("font2_path", ["font2", "font2_path"], str, "Font 2 path", "Secondary font for font2_chars below."),
+    ("font2_composer_cap_height", ["font2", "font2_composer_cap_height"], float, "Font 2 cap height (pt)", ""),
+    ("font2_chars", ["font2", "font2_chars"], str, "Font 2 chars", "Characters that use font2 instead of font."),
+    ("mode", ["alignment", "mode"], str, "Align mode", '"center" or "left" (v2 H_Alignment) - CRITICAL, real value "left".'),
+    ("x_pos_offset", ["alignment", "x_pos_offset"], float, "X position offset (mm)",
+     "v2 X_Pos_Offset_Composer_ - CRITICAL, print-affecting, verified against v2 line-by-line."),
+    ("y_pos_offset", ["alignment", "y_pos_offset"], float, "Y position offset (mm)",
+     "v2 Y_Pos_Offset_Composer - CRITICAL, print-affecting, verified against v2 line-by-line."),
+    ("custom_h_chars", ["alignment", "custom_h_chars"], str, "Custom H-align chars", "Get an extra horizontal offset (below)."),
+    ("custom_h_offset", ["alignment", "custom_h_offset"], float, "Custom H-align offset (mm)", ""),
+    ("custom_v_chars", ["alignment", "custom_v_chars"], str, "Custom V-align chars", "Get an extra vertical offset (below)."),
+    ("custom_v_offset", ["alignment", "custom_v_offset"], float, "Custom V-align offset (mm)", ""),
+    ("draft_angle_deg", ["build", "draft_angle_deg"], float, "Draft angle (deg)",
+     "Half-angle of the Minkowski draft cone each character is swept with. Real value 55."),
+]
+
+LABEL_FIELDS_SELECTRIC = [
+    ("enabled", ["label", "enabled"], bool, "Label enabled", "v2 Label - typeface name engraved on the top face."),
+    ("arrow_enabled", ["label", "arrow_enabled"], bool, "Arrow enabled", "v2 Arrow - alignment marker triangle."),
+    ("show_number", ["label", "show_number"], bool, "Show number label", "v2: on for Selectric I/II & III, off for Composer."),
+    ("label_no", ["label", "label_no"], str, "Number label text", "v2 Label_No, e.g. \"10\"."),
+    ("label_text_override", ["label", "label_text_override"], str, "Typeface label override", "Blank adopts the font's own name (font.name)."),
+    ("label_no_font_override", ["label", "label_no_font_override"], str, "Number label font override", "Blank adopts font.path."),
+    ("label_font_override", ["label", "label_font_override"], str, "Typeface label font override", "Blank adopts font.path."),
+    ("no_label_size", ["label", "no_label_size"], float, "Number label size (mm)", ""),
+    ("no_label_offset", ["label", "no_label_offset"], float, "Number label vertical offset (mm)", ""),
+    ("font_label_size", ["label", "font_label_size"], float, "Typeface label size (mm)", ""),
+    ("font_label_offset", ["label", "font_label_offset"], float, "Typeface label vertical offset (mm)", ""),
+    ("del_base_from_centre", ["label", "del_base_from_centre"], float, "Arrow distance from center (mm)", ""),
+    ("del_depth", ["label", "del_depth"], float, "Label/arrow deboss depth (mm)", ""),
+]
+
+QUALITY_FIELDS_SELECTRIC = [
+    ("points_per_mm", ["build", "points_per_mm"], float, "Outline density (pts/mm)", "Glyph curve sampling density."),
+    ("minkowski_enabled", ["build", "minkowski_enabled"], bool, "Minkowski draft", "Off: fast undrafted preview (correct platen curve/placement, no taper)."),
+    ("character_block_height_mm", ["build", "character_block_height_mm"], float, "Character block height (mm)",
+     "v2's linear_extrude(6) construction margin - must exceed any character's real embed depth."),
+    ("mink_cone_height_mm", ["build", "mink_cone_height_mm"], float, "Minkowski cone height (mm)", "v2's hardcoded cylinder h=2 in the draft cone."),
+    ("surface_fn", ["quality", "surface_fn"], int, "Surface fn", "Sphere/skirt/roof/boss facet count."),
+    ("cyl_fn", ["quality", "cyl_fn"], int, "Cylinder fn", "Shaft bore and the real platen cutout cylinder (v2 shares one Cyl_Fn for both)."),
+    ("minkowski_fn", ["quality", "minkowski_fn"], int, "Minkowski fn", "Draft cone segments - biggest cost lever with points_per_mm."),
+]
+
+RESIN_FIELDS_SELECTRIC = [
+    ("resin_fn", ["resin", "resin_fn"], int, "Resin fn", ""),
+    ("tip_od", ["resin", "tip_od"], float, "Tip OD (mm)", "v2 Tip_D."),
+    ("tip_notch_od", ["resin", "tip_notch_od"], float, "Notch tip OD (mm)", "v2 Tip_Notch_D - used for the drive-notch's own supports."),
+    ("tip_notch_offset", ["resin", "tip_notch_offset"], float, "Notch support angle offset (deg)", "v2 Tip_Notch_Offset."),
+    ("tip_in", ["resin", "tip_in"], float, "Tip inset (mm)", "v2 Tip_In."),
+    ("tip_h", ["resin", "tip_h"], float, "Tip height (mm)", "v2 Tip_H."),
+    ("rod_od", ["resin", "rod_od"], float, "Rod OD (mm)", "v2 Rod_D."),
+    ("base_od", ["resin", "base_od"], float, "Raft OD (mm)", "v2 Base_D - mapped to the shared resin_support.resin_rod()'s raft_od."),
+    ("base_h", ["resin", "base_h"], float, "Raft thickness (mm)", "v2 Base_H - mapped to raft_thickness (v2's own base-chamfer ratio isn't replicated, see the resin: section comment)."),
+    ("min_rod_h", ["resin", "min_rod_h"], float, "Min rod height (mm)", "v2 Min_Rod_H."),
+    ("resin_detent_clock_offset", ["resin", "resin_detent_clock_offset"], float, "Detent support clock offset (deg)", "v2 Resin_Detent_Clock_Offset."),
+]
+
+# element: schema is byte-identical across all 3 Selectric machines (same
+# physical ball) - one shared table.
+ELEMENT_FIELDS_SELECTRIC = [
+    ("sphere_od", ["element", "sphere_od"], float, "Sphere OD (mm)", "v2 Sphere_OD."),
+    ("max_od", ["element", "max_od"], float, "Max character OD (mm)", "v2 Max_OD - character-concave to character-concave diameter."),
+    ("top_flat_to_center", ["element", "top_flat_to_center"], float, "Top flat to center (mm)", "v2 Top_Flat_To_Center."),
+    ("top_flat_thickness", ["element", "top_flat_thickness"], float, "Top flat thickness (mm)", ""),
+    ("top_chamfer", ["element", "top_chamfer"], float, "Top shaft chamfer (mm)", "v2 Top_Chamfer."),
+    ("inside_id", ["element", "inside_id"], float, "Inside ID (mm)", "v2 Inside_ID."),
+    ("boss_od", ["element", "boss_od"], float, "Boss OD (mm)", ""),
+    ("boss_clearance", ["element", "boss_clearance"], float, "Boss clearance (mm)", ""),
+    ("boss_step", ["element", "boss_step"], float, "Boss step thickness (mm)", ""),
+    ("boss_to_center_base", ["element", "boss_to_center_base"], float, "Boss to center, base (mm)", "v2 Boss_To_Center_ - snoot_droop_compensation is added on top."),
+    ("snoot_droop_compensation", ["element", "snoot_droop_compensation"], float, "Snoot droop compensation (mm)",
+     "CRITICAL print-fit value - v2's own echo() warning: adjust until a printed boss measures 8.5mm to the top flat."),
+    ("shaft_id", ["element", "shaft_id"], float, "Shaft ID (mm)", ""),
+    ("skirt_top_od", ["element", "skirt_top_od"], float, "Skirt top OD (mm)", ""),
+    ("skirt_bottom_od", ["element", "skirt_bottom_od"], float, "Skirt bottom OD (mm)", ""),
+    ("platen_diameter", ["element", "platen_diameter"], float, "Platen diameter (mm)", "v2 Platen_OD - 36 for Selectric I/II & III, 43 for Composer."),
+    ("drive_notch_width", ["element", "drive_notch_width"], float, "Drive notch width (mm)", ""),
+    ("drive_notch_height", ["element", "drive_notch_height"], float, "Drive notch height (mm)", ""),
+    ("drive_notch_theta", ["element", "drive_notch_theta"], float, "Drive notch angle (deg)", "v2 Drive_Notch_Theta_."),
+    ("detent_valley_to_center", ["element", "detent_valley_to_center"], float, "Detent valley to center (mm)", ""),
+    ("detent_skirt_clock_offset", ["element", "detent_skirt_clock_offset"], float, "Detent skirt clock offset (deg)", ""),
+    ("floor", ["element", "floor"], float, "Floor - center to detent teeth tips (mm)",
+     "v2's own measured reference value, not derived from other fields here."),
+]
+
 SECTIONS_BY_MACHINE = {
     "blickensderfer": {**SECTIONS_COMMON, "Logo": LOGO_FIELDS_BLICKPOSTAL,
                        "Quality": QUALITY_FIELDS_BLICKPOSTAL, "Resin": RESIN_FIELDS_BLICKPOSTAL,
@@ -779,6 +910,19 @@ SECTIONS_BY_MACHINE = {
     "hammond": {**SECTIONS_COMMON, "Label": LABEL_FIELDS_HAMMOND,
                 "Quality": QUALITY_FIELDS_HAMMOND, "Resin": RESIN_FIELDS_HAMMOND,
                 "Element": ELEMENT_FIELDS_HAMMOND},
+    # No SECTIONS_COMMON reuse at all - Selectric's alignment/calibration
+    # schema doesn't match the cylinder family's (see FONT_FIELDS_
+    # SELECTRIC12's own comment above). No "Gauge"/"Logo"/"Calibration"
+    # key - see this dict's own leading comment.
+    "selectric12": {"Font & Alignment": FONT_FIELDS_SELECTRIC12, "Label": LABEL_FIELDS_SELECTRIC,
+                    "Quality": QUALITY_FIELDS_SELECTRIC, "Resin": RESIN_FIELDS_SELECTRIC,
+                    "Element": ELEMENT_FIELDS_SELECTRIC},
+    "selectric3": {"Font & Alignment": FONT_FIELDS_SELECTRIC12, "Label": LABEL_FIELDS_SELECTRIC,
+                   "Quality": QUALITY_FIELDS_SELECTRIC, "Resin": RESIN_FIELDS_SELECTRIC,
+                   "Element": ELEMENT_FIELDS_SELECTRIC},
+    "selectric_composer": {"Font & Alignment": FONT_FIELDS_SELECTRIC_COMPOSER, "Label": LABEL_FIELDS_SELECTRIC,
+                           "Quality": QUALITY_FIELDS_SELECTRIC, "Resin": RESIN_FIELDS_SELECTRIC,
+                           "Element": ELEMENT_FIELDS_SELECTRIC},
 }
 
 # Static intro banner shown above a section tab's fields, keyed by section
@@ -1507,6 +1651,17 @@ class TuneApp(App):
         self.SECTIONS = SECTIONS_BY_MACHINE.get(self.machine, SECTIONS_BY_MACHINE["blickensderfer"])
         self.FIELDS = [field for fields in self.SECTIONS.values() for field in fields]
         self.LAYOUT_PRESETS = LAYOUT_PRESETS_BY_MACHINE.get(self.machine, {})
+        # Selectric machines have no editable keyboard-layout concept at
+        # all (fixed hemisphere character map, not a user-selectable
+        # preset - see lib/layouts/selectric12_layout.py) - gates the
+        # Layout tab and every baseline_row/cutout_row-style widget
+        # (compose()/_save_to_yaml/_refresh_widgets_from_cfg), same
+        # pattern as "Gauge" in self.SECTIONS for machines with no Shaft
+        # Gauge Test.
+        self.HAS_LAYOUT_TAB = "rows" in self.cfg.get("layout", {})
+        if not self.HAS_LAYOUT_TAB:
+            self.BASELINE_CUTOUT_KEYS = []
+            return
         # row count varies per machine (3 for Blickensderfer/Postal, 7 for
         # Mignon) - see BASELINE_CUTOUT_KEYS' module comment. Hammond's
         # own presets additionally vary in row count from EACH OTHER
@@ -1756,6 +1911,11 @@ class TuneApp(App):
     ROW_LABELS = ["lowercase", "uppercase", "figs"]
 
     def _compose_baseline_cutout_fields(self):
+        # No layout.baseline_row/cutout_row concept at all for machines
+        # with no editable keyboard layout (self.HAS_LAYOUT_TAB False,
+        # self.BASELINE_CUTOUT_KEYS empty - see that flag's own comment).
+        if not self.HAS_LAYOUT_TAB:
+            return
         yield Static(
             "Per-row baseline/platen-cutout (mm). See the Calibration tab "
             "to find these empirically.",
@@ -1859,9 +2019,11 @@ class TuneApp(App):
 
     def _compose_build_tab(self):
         has_gauge = "Gauge" in self.SECTIONS
+        has_calibration = "Calibration" in self.SECTIONS
         is_hammond = self.machine == "hammond"
         hammond_parts = ("none",) if is_hammond else ()
-        valid_targets = ("element", "calibration") + (("gauge",) if has_gauge else ()) + hammond_parts
+        valid_targets = (("element",) + (("calibration",) if has_calibration else ())
+                          + (("gauge",) if has_gauge else ()) + hammond_parts)
         with TabPane("Build", id="tab-build"):
             with VerticalScroll():
                 with Vertical(classes="picker-row"):
@@ -1878,7 +2040,8 @@ class TuneApp(App):
                     options = [(element_label, "element")]
                     if has_gauge:
                         options.append(("Shaft Gauge", "gauge"))
-                    options.append((f"Calibration {element_label}", "calibration"))
+                    if has_calibration:
+                        options.append((f"Calibration {element_label}", "calibration"))
                     if is_hammond:
                         # "None" - no main shuttle/calibration body at all,
                         # just RibOnly() (hammond.RibOnly(), a plain FDM
@@ -1919,13 +2082,16 @@ class TuneApp(App):
                     "always includes its own resin supports regardless of this "
                     "checkbox."
                 ) if has_gauge else ""
+                calibration_help = (
+                    f" Calibration {element_label}: strikes the same test "
+                    "character everywhere, sweeping baseline or cutout per column "
+                    "(see the Calibration tab) to find layout.baseline_row/cutout_row."
+                ) if has_calibration else ""
                 resin_unavailable = RESIN_SUPPORT_UNAVAILABLE_NOTE.get(self.machine, "")
                 yield Static(
                     "Element: the real element. Turn on Resin supports to add "
                     "rods/breakaway ring (see the Resin tab for those settings)."
-                    f"{gauge_help} Calibration Element: strikes the same test "
-                    "character everywhere, sweeping baseline or cutout per column "
-                    "(see the Calibration tab) to find layout.baseline_row/cutout_row."
+                    f"{gauge_help}{calibration_help}"
                     f"{resin_unavailable}",
                     classes="picker-help")
 
@@ -2009,9 +2175,16 @@ class TuneApp(App):
                 yield from self._compose_section_tab("Resin")
                 if "Gauge" in self.SECTIONS:
                     yield from self._compose_section_tab("Gauge")
-                yield from self._compose_section_tab("Calibration")
+                # no "Calibration" key for the Selectric family - no
+                # CalibrationElement/CalibrationAdditive implemented yet
+                # (see SECTIONS_BY_MACHINE's Selectric comment).
+                if "Calibration" in self.SECTIONS:
+                    yield from self._compose_section_tab("Calibration")
                 yield from self._compose_build_tab()
-                yield from self._compose_layout_tab()
+                # no editable keyboard-layout concept for the Selectric
+                # family (see self.HAS_LAYOUT_TAB's own comment).
+                if self.HAS_LAYOUT_TAB:
+                    yield from self._compose_layout_tab()
                 yield from self._compose_section_tab("Quality")
                 # no "Logo" key for Bennett - its one engraved-text feature
                 # is the "Label" tab instead (see LABEL_FIELDS_BENNETT).
@@ -2102,38 +2275,39 @@ class TuneApp(App):
         for key in self.BASELINE_CUTOUT_KEYS:
             arr_key, index_str = key.rsplit("_", 1)
             text = patch_yaml_list_item(text, arr_key, int(index_str), values[key])
-        modify_glyphs = self.query_one("#layout-modify-glyphs", Switch).value
-        text = patch_yaml_value(text, "modify_glyphs", modify_glyphs)
-        if modify_glyphs:
-            # the hand-edited copy is authoritative over the preset
-            # dropdown while unlocked - "fix" (defensively re-clamp) each
-            # row to the placement_map cap in case anything bypassed the
-            # Input's own max_length (e.g. a paste)
-            char_cap = len(self.cfg["layout"]["placement_map"])
-            n_rows = len(self.cfg["layout"]["rows"])
-            custom_rows = [self.query_one(f"#layout-custom-row-{i}", Input).value[:char_cap] for i in range(n_rows)]
-            text = patch_yaml_rows(text, custom_rows)
-        else:
-            layout_select = self.query_one("#layout-select", Select)
-            if layout_select.value is not Select.NULL:
-                text = patch_yaml_rows(text, self.LAYOUT_PRESETS[layout_select.value])
-                # baseline_row/cutout_row themselves are NOT force-
-                # overwritten here from LAYOUT_PRESET_BASELINE_ROW_BY_
-                # MACHINE on every save - an earlier version of this did
-                # that unconditionally, which silently discarded any
-                # manual edit to those fields every time a save happened
-                # while a preset remained selected (i.e. essentially
-                # always, since "custom" requires Modify glyphs). The
-                # BASELINE_CUTOUT_KEYS loop above already saves whatever
-                # is actually showing in the (now always-4-rows-wide,
-                # see _compose_baseline_cutout_fields) widgets, appending
-                # a 4th entry via patch_yaml_list_item if needed - that's
-                # the real, editable, save-preserving value. The preset's
-                # own real defaults are instead pre-filled into those
-                # SAME widgets live, the moment the dropdown selection
-                # changes (see on_select_changed) - a one-time seed the
-                # user can still hand-edit before saving, not a
-                # recurring overwrite.
+        if self.HAS_LAYOUT_TAB:
+            modify_glyphs = self.query_one("#layout-modify-glyphs", Switch).value
+            text = patch_yaml_value(text, "modify_glyphs", modify_glyphs)
+            if modify_glyphs:
+                # the hand-edited copy is authoritative over the preset
+                # dropdown while unlocked - "fix" (defensively re-clamp) each
+                # row to the placement_map cap in case anything bypassed the
+                # Input's own max_length (e.g. a paste)
+                char_cap = len(self.cfg["layout"]["placement_map"])
+                n_rows = len(self.cfg["layout"]["rows"])
+                custom_rows = [self.query_one(f"#layout-custom-row-{i}", Input).value[:char_cap] for i in range(n_rows)]
+                text = patch_yaml_rows(text, custom_rows)
+            else:
+                layout_select = self.query_one("#layout-select", Select)
+                if layout_select.value is not Select.NULL:
+                    text = patch_yaml_rows(text, self.LAYOUT_PRESETS[layout_select.value])
+                    # baseline_row/cutout_row themselves are NOT force-
+                    # overwritten here from LAYOUT_PRESET_BASELINE_ROW_BY_
+                    # MACHINE on every save - an earlier version of this did
+                    # that unconditionally, which silently discarded any
+                    # manual edit to those fields every time a save happened
+                    # while a preset remained selected (i.e. essentially
+                    # always, since "custom" requires Modify glyphs). The
+                    # BASELINE_CUTOUT_KEYS loop above already saves whatever
+                    # is actually showing in the (now always-4-rows-wide,
+                    # see _compose_baseline_cutout_fields) widgets, appending
+                    # a 4th entry via patch_yaml_list_item if needed - that's
+                    # the real, editable, save-preserving value. The preset's
+                    # own real defaults are instead pre-filled into those
+                    # SAME widgets live, the moment the dropdown selection
+                    # changes (see on_select_changed) - a one-time seed the
+                    # user can still hand-edit before saving, not a
+                    # recurring overwrite.
         type_test_text = self.query_one("#type-test-text", TextArea).text
         text = patch_yaml_text_block(text, "text", type_test_text)
         with open(self.config_path, "w") as f:
@@ -2160,11 +2334,14 @@ class TuneApp(App):
                 widget.value = bool(current)
             else:
                 widget.value = str(current)
-        preset_now = self._current_layout_preset()
-        self.query_one("#layout-select", Select).value = preset_now if preset_now else Select.NULL
+        if self.HAS_LAYOUT_TAB:
+            preset_now = self._current_layout_preset()
+            self.query_one("#layout-select", Select).value = preset_now if preset_now else Select.NULL
         target_now = self.cfg.get("build", {}).get("target", "element")
         hammond_parts = ("none",) if self.machine == "hammond" else ()
-        valid_targets = ("element", "calibration") + (("gauge",) if "Gauge" in self.SECTIONS else ()) + hammond_parts
+        has_calibration = "Calibration" in self.SECTIONS
+        valid_targets = (("element",) + (("calibration",) if has_calibration else ())
+                          + (("gauge",) if "Gauge" in self.SECTIONS else ()) + hammond_parts)
         if target_now not in valid_targets:
             # "resin" was a valid target value before the Build tab's
             # dropdown was split into target + a separate Resin supports
@@ -2182,6 +2359,8 @@ class TuneApp(App):
         self.query_one("#type-test-cpi", Input).value = str(self.cfg["type_test"]["cpi"])
         self.query_one("#type-test-lpi", Input).value = str(self.cfg["type_test"]["lpi"])
         self.query_one("#type-test-text", TextArea).text = self.cfg["type_test"]["text"]
+        if not self.HAS_LAYOUT_TAB:
+            return
         display_rows = self._display_rows_for_preset()
         for i in range(len(display_rows)):
             self._update_row_widget("layout-original-row", i, display_rows[i])
@@ -2417,24 +2596,44 @@ class TuneApp(App):
             self.log_line("[red]test text is empty[/red]")
             return
         font_path = self.inputs["path"].value
-        font_size_mm = self.inputs["size_mm"].value
+        # Selectric Composer sizes type by cap-height (font.
+        # composer_cap_height/2.834 = Font_Size_Selected, see lib/
+        # selectric_composer.py's configure()) instead of a direct
+        # font.size_mm - every other machine (including Selectric I/II &
+        # III) has "size_mm" in self.inputs directly.
+        if "size_mm" in self.inputs:
+            font_size_mm = self.inputs["size_mm"].value
+        else:
+            font_size_mm = str(float(self.inputs["composer_cap_height"].value) / 2.834)
         out_path = os.path.join(REPO_ROOT, self.cfg["output"]["directory"], self.cfg["output"]["stl_name"])
         self.log_line(f"[bold]--- Type Test (overwrites {out_path}) ---[/bold]")
         cmd = [sys.executable, os.path.join(REPO_ROOT, "type_test.py"), text,
-               "--cpi", str(cpi), "--lpi", str(lpi), "--font-path", font_path, "--font-size-mm", font_size_mm,
-               # same horizontal-alignment convention as the real element
-               # (advance-box center/left + modified_left/right nudges) -
-               # read live off the Font & Alignment tab's own widgets
-               "--align-mode", self.inputs["mode"].value,
-               "--center-offset-mm", self.inputs["center_offset_mm"].value,
-               "--left-offset-mm", self.inputs["left_offset_mm"].value,
-               # "=" form, not space-separated, in case the chars field
-               # starts with "-" (would otherwise look like another flag)
-               "--modified-left-chars=" + self.inputs["modified_left_chars"].value,
-               "--modified-left-offset-mm", self.inputs["modified_left_offset_mm"].value,
-               "--modified-right-chars=" + self.inputs["modified_right_chars"].value,
-               "--modified-right-offset-mm", self.inputs["modified_right_offset_mm"].value,
-               "--out", out_path]
+               "--cpi", str(cpi), "--lpi", str(lpi), "--font-path", font_path, "--font-size-mm", font_size_mm]
+        # same horizontal-alignment convention as the real element
+        # (advance-box center/left + modified_left/right nudges) - read
+        # live off the Font & Alignment tab's own widgets. Selectric
+        # (mode only, no center_offset_mm/left_offset_mm/modified_*
+        # concept - see FONT_FIELDS_SELECTRIC12) just passes --align-mode
+        # and lets type_test.py's own defaults (0/empty) cover the rest -
+        # this is a v4-only flat preview, not required to replicate the
+        # real element's alignment pipeline exactly for any machine.
+        if "mode" in self.inputs:
+            cmd += ["--align-mode", self.inputs["mode"].value]
+        if "center_offset_mm" in self.inputs:
+            cmd += ["--center-offset-mm", self.inputs["center_offset_mm"].value]
+        if "left_offset_mm" in self.inputs:
+            cmd += ["--left-offset-mm", self.inputs["left_offset_mm"].value]
+        if "modified_left_chars" in self.inputs:
+            # "=" form, not space-separated, in case the chars field
+            # starts with "-" (would otherwise look like another flag)
+            cmd += ["--modified-left-chars=" + self.inputs["modified_left_chars"].value]
+        if "modified_left_offset_mm" in self.inputs:
+            cmd += ["--modified-left-offset-mm", self.inputs["modified_left_offset_mm"].value]
+        if "modified_right_chars" in self.inputs:
+            cmd += ["--modified-right-chars=" + self.inputs["modified_right_chars"].value]
+        if "modified_right_offset_mm" in self.inputs:
+            cmd += ["--modified-right-offset-mm", self.inputs["modified_right_offset_mm"].value]
+        cmd += ["--out", out_path]
         returncode = await self._stream_subprocess(cmd)
         if returncode == 0:
             self._last_build_info = {


### PR DESCRIPTION
## Summary
- Splits `v2/ibm.scad`'s 3 `Render_Mode` branches into 3 independent v4 machines (`selectric12`, `selectric3`, `selectric_composer`) sharing a new `lib/spherical_machine.py` for the geometry that's byte-identical across all three - the spherical-typeball analogue of `lib/cylinder_machine.py`.
- Wires all 3 into `tune.py` (new field tables, `MACHINES` entries) and fixes 3 latent `tune.py` bugs the cylinder family's uniform config schema had been masking - see SESSION_LOG.md part 41.
- Fixes 3 real geometry bugs found via visual inspection in a real STL viewer (not caught by watertight/volume checks alone): missing `translate([0,0,Floor])` before unioning resin supports (rods at wrong heights), a fabricated rectangle in `HollowProfile3()`'s hull (malformed interior cavity), and an incorrectly-shared rotation on the notch-support strut's two endpoints (stray connecting rods).

## Verification
- [x] All 3 machines built via `generate.py` with real Minkowski draft + resin supports: watertight, valid, volumes cluster tightly (~7.96-8.26cm3, expected - same physical ball)
- [x] `tune.py` verified headless (`TuneApp(...).run_test()`) against scratch configs: compose/collect/save/refresh cycle, plus real `generate.py`/`type_test.py` subprocess builds, for all 3 new machines
- [x] Regression-checked `tune.py` changes against Blickensderfer and Hammond - no breakage
- [x] User visually confirmed the resin-rod-height and hollow-cavity fixes in a real STL viewer (F3D)
- [ ] User has not yet re-checked the notch-support-strut fix (rebuilt, not yet reviewed)

## Deferred (tracked in SESSION_LOG.md parts 40-41)
Calibration entry points, drain holes, Composer's own pica type-test system, non-US language variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)