### PR TITLE
tune.py: fix _migrate_running_config dropping block-list values on backfill

### DIFF
--- a/v4/tune.py
+++ b/v4/tune.py
@@ -2220,7 +2220,21 @@ class TuneApp(App):
                 else master_text[sec_start:]
             additions = []
             for sk in missing_subkeys:
-                sub_m = re.search(rf'(^|\n)((?:[ \t]*#[^\n]*\n)*[ \t]+{re.escape(sk)}:.*?)(?=\n[ \t]*\S|\Z)',
+                # Terminating lookahead must require the SAME indentation as
+                # the subkey's own line (\3, backreferenced), not just "any
+                # indented non-blank line" - a block-list value (e.g.
+                # layout.rows) has its "- ..." items indented DEEPER than the
+                # `rows:` line itself, and those items also satisfy a bare
+                # "[ \t]*\S" lookahead, so the old regex stopped matching
+                # right after the `key:` line and silently dropped every
+                # list item, backfilling a blank `rows:` (i.e. YAML null)
+                # into the running copy - confirmed live: a selectric_
+                # composer.running.yaml whose layout: section predated
+                # layout.rows existing in master got exactly this, corrupting
+                # `rows` to null and crashing _layout_row_caps() on load.
+                # Requiring \3 (same indent) means only a true sibling key
+                # ends the match.
+                sub_m = re.search(rf'(^|\n)((?:[ \t]*#[^\n]*\n)*([ \t]+){re.escape(sk)}:.*?)(?=\n\3\S|\Z)',
                                    sec_body, re.DOTALL)
                 if sub_m:
                     additions.append(sub_m.group(2).rstrip("\n"))


### PR DESCRIPTION
## Summary
- `TuneApp._migrate_running_config()`'s per-subkey backfill regex used a
  lookahead (`(?=\n[ \t]*\S|\Z)`) that terminated on ANY indented
  non-blank line, not just a true sibling key at the same indentation.
- For a block-list subkey like `layout.rows`, each `- "..."` item line
  (indented deeper than `rows:` itself) also satisfies that lookahead,
  so the match stopped right after the `rows:` line and dropped every
  list item - backfilling a blank `rows:` (YAML null) into the running
  config instead of the real list.
- This crashed `tune.py`'s `_layout_row_caps()` with
  `TypeError: 'NoneType' object is not iterable` the next time the
  affected running config was loaded (hit live on a
  `selectric_composer.running.yaml` that predated `layout.rows` being
  added to `config/selectric_composer.yaml` in commit `eb0773e`).
- Fix: require the lookahead to match the subkey's own indentation via
  a backreference, so only a real sibling key (same or lesser indent)
  ends the match, not a deeper-indented continuation line.

## Test plan
- [x] Reproduced the exact failure against scratch copies (never the
      real master/running configs, per this repo's own `tune.py`
      warning): stripped `layout.rows`/`layout.modify_glyphs` from a
      copy of `config/selectric_composer.yaml` to simulate a
      pre-`eb0773e` running config, ran `_migrate_running_config()`
      against it, confirmed the old regex reproduces the blank-`rows:`
      bug and the new regex backfills the full 8-item list correctly.
- [x] `python3 -m py_compile tune.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)