### PR TITLE
v4: port Type Slugs (v1) into 5 new machines

### DIFF
--- a/v4/CLAUDE.md
+++ b/v4/CLAUDE.md
@@ -199,9 +199,13 @@ the cited section for the full incident).
 
 - **Physical form and code-sharing are two separate axes - check both,
   don't infer one from the other.** Ported so far: Blickensderfer,
-  Postal, Mignon, Bennett, Helios Klimax, Hammond, Hammond Split, and
+  Postal, Mignon, Bennett, Helios Klimax, Hammond, Hammond Split,
   IBM/Selectric (split into 3 machines - `selectric12`, `selectric3`,
-  `selectric_composer` - sharing `lib/spherical_machine.py`; see below).
+  `selectric_composer` - sharing `lib/spherical_machine.py`; see below),
+  and the standalone Type Slug family (`type_slug`/`vogue_slug`/
+  `gauge_slug` sharing `lib/wing_slug.py`, `oliver_slug`/`lumi_slug`
+  sharing `lib/box_slug.py` - ground truth v1, not v2, since this family
+  was never carried into v2 at all; see `SESSION_LOG.md` part 75).
   Nothing else remains on the roadmap. All of Blickensderfer/Postal/
   Mignon/Bennett/Helios are cylindrical in outward form, but:
   - **Blickensderfer and Postal are near-twins** - they diverge in code

--- a/v4/SESSION_LOG.md
+++ b/v4/SESSION_LOG.md
@@ -5222,3 +5222,30 @@ Not done in this pass (no signal it's wanted, and matches Selectric's
 own precedent of deferring the same feature at first port):
 `CalibrationElement`/`CalibrationAdditive` for any of the 5 new
 machines.
+
+**Correction, found by the user running the real TUI (not caught by
+this part's own "headless-tested" verification claim above):**
+`_compose_tuner_ui()` never actually called `_compose_section_tab
+("Character")`/`("Ticks")` for the two new section names this port
+added - `self.FIELDS` (built by flattening `SECTIONS_BY_MACHINE`)
+included their fields regardless, so `self.inputs` (populated only by
+`_compose_section_tab` actually running) was missing entries for them,
+crashing on `self.inputs[key]` (`KeyError: 'char_enabled'`) the moment
+any generic FIELDS loop touched one - reproduced live via "Reset to
+Defaults". The headless test this part described above only exercised
+`TuneApp.__init__` (SECTIONS/FIELDS construction, `patch_yaml_value()`
+round-trips against raw config values) - it never actually mounted the
+app, so it could not have caught a missing-`_compose_section_tab()`-call
+bug like this one. Fixed by adding the two missing `if "Character"/
+"Ticks" in self.SECTIONS: yield from self._compose_section_tab(...)`
+calls. Re-verified properly this time using Textual's own
+`App.run_test()` harness (which DOES mount the app for real) - confirms
+every one of the 5 new machines' `self.FIELDS` now has a real widget in
+`self.inputs`, and reproduces+confirms-fixed the exact `action_reset_
+defaults()` crash path the user hit; also re-ran the same `run_test()`
+check against `bennett`/`selectric12` to confirm the two new
+conditional blocks don't affect any existing machine. Lesson for next
+time: a "headless" tune.py test that never calls `run_test()`/mounts
+the app cannot verify anything about widget composition or `self.
+inputs` - construction-only testing of `TuneApp` is real but partial
+coverage, not a substitute for actually mounting it.

--- a/v4/SESSION_LOG.md
+++ b/v4/SESSION_LOG.md
@@ -5055,3 +5055,170 @@ found) despite not delivering the dramatic win originally expected -
 worth having on general principle (matches cylinder_machine's own
 proven pattern) even without a large measured benefit on this
 particular workload.
+
+## 75. Type Slug family ported - 5 new machines, v1 (not v2) as ground truth (2026-07-28)
+
+User asked to migrate "type slugs" into v4, framing them as "more for
+novelty, not real stuff." These turned out to live ONLY in
+`v1/Type Slugs/*.scad` - standalone decorative type-slug replicas that
+were never carried into v2 at all (unlike every other v4 machine so
+far), so this port's ground truth is v1 directly, a first for this
+codebase - config YAML/lib code below cross-reference v1 line numbers
+the way every other machine cross-references v2 line numbers.
+
+**Taxonomy** (verified function-by-function against both real v1
+sources before writing anything, per CLAUDE.md's own rule): two
+genuinely different body-construction engines, not five independent
+ports or one grab-bag module.
+- **"Wing body" family** (`lib/wing_slug.py` shared engine): rounded
+  hull body (4 corner posts + 2 wing-radius cylinders), real Minkowski-
+  drafted struck text, optional SVG logo, resin support, loop/post/
+  side-hole. Three thin variants: `lib/type_slug.py` (TypeSlug.scad, the
+  generic base engine), `lib/vogue_slug.py` (VogueSlug.scad, carries the
+  real 2-piece "Vogue Foundry" mark + True_Vogue font - the one replica
+  modeled from real drawings), `lib/gauge_slug.py` (GaugeTypeSlugSlug.
+  scad - no text/logo at all, a tick-mark measuring ladder instead; per
+  the user's own clarification, this is the ONE real functional member
+  of the family, meant to install on the machine and measure/calibrate,
+  not a novelty).
+- **"Box body" family** (`lib/box_slug.py` shared engine): plain
+  rectangular body, straight polygon-cut wing tapers, N stacked struck
+  characters (config-driven list length) + N platen cylinders, no logo,
+  no resin support at all. Two thin variants: `lib/oliver_slug.py`
+  (OliverSlug.scad, 3 chars, a real Oliver typewriter slug replica),
+  `lib/lumi_slug.py` (LumiSlug.scad, 4 chars + a loop pendant, pure
+  novelty).
+- Same "shared engine + thin variant" split `lib/spherical_machine.py` +
+  `lib/selectric12.py`/`selectric3.py`/`selectric_composer.py` already
+  established - confirmed applicable here independently, not assumed
+  from that precedent.
+
+**New shared infrastructure, not machine-specific:**
+- `lib/svg_import.py` - v4 had no SVG-import capability at all (v1 relied
+  on OpenSCAD's built-in `import(svg)`). Real from-scratch path-data
+  parser (M/L/H/V/C/S/Q/T/A/Z, absolute+relative) reusing `glyph_poc`'s
+  adaptive de Casteljau bezier flattening for curves and elliptical-arc-
+  to-bezier conversion for `A`, feeding `glyph_poc.classify_and_
+  triangulate()`'s existing nesting-depth hole/island fill logic (same
+  problem a multi-path logo has as a multi-contour glyph). Deliberately
+  does NOT reproduce OpenSCAD's own px/DPI SVG-import scaling convention
+  (would need the same kind of empirical DPI calibration `glyph_poc.
+  OPENSCAD_TEXT_DPI_FACTOR` needed for `text()` - not worth it for a
+  decorative logo mark, not a physically-toleranced struck character) -
+  callers pick their own `logo.scale_mm_per_unit` explicitly instead of
+  inheriting v1's `SVG_Scale=1/40*SVG_Size`.
+- `scad_primitives.torus()` - extracted since `wing_slug.Loop()`/
+  `box_slug.Loop()` both need the exact same torus recipe (byte-
+  identical between TypeSlug.scad's and LumiSlug.scad's real Loop
+  blocks).
+
+**Real bugs found and fixed during this port (not shipped):**
+1. **`sp.scad_transform()` op-ordering, backwards in 5 of 7 initial call
+   sites.** Re-derived the convention carefully against `spherical_
+   machine.py`'s own `PlatenCutout()` (3 chained ops with an explicit
+   "source top-to-bottom" comment matching its ops list order 1:1) -
+   confirmed the rule is ops-list-order = literal source top-to-bottom
+   order (whichever transform is OUTERMOST/appears first in the nested
+   OpenSCAD source goes FIRST in the list). Caught and fixed in
+   `_wing_cyl_verts`, `_platen_cyl_pair`, `CopyrightText`, `PostHole`,
+   `SideHole` before ever running geometry - `Post()`/`Loop()` were
+   already correct. Would have silently produced wrong (but still
+   watertight-looking) part geometry if shipped.
+2. **`scad_primitives.torus()`'s initial single `sections` parameter
+   drove BOTH the tube cross-section AND the sweep resolution** (matching
+   v1's own literal `$fn=360` reused for both `rotate_extrude` and its
+   child `circle()`) - measured a real 129,600-vertex torus for one
+   small keyring loop (confirmed via Lumi Slug's real config values: a
+   66K-vertex FullElement for 4 characters vs Oliver Slug's 630-vertex
+   FullElement for 3, a disproportionate jump that was the actual tell).
+   Split into independent `sections` (sweep, stays 360) and
+   `tube_sections` (new `quality.loop_tube_fn` knob, default 32) -
+   verts dropped ~10x fleet-wide with no visible quality loss, still a
+   real, own config knob per CLAUDE.md's facet-count-in-YAML rule, not a
+   hardcoded reduction.
+3. **`tune.py` FIELDS key collisions** - `character.enabled`/`logo.
+   enabled`/`gauge.enabled` all being the bare YAML key `enabled` (and
+   `logo.depth_mm`/`label.depth_mm` both being `depth_mm`) would have
+   broken `patch_yaml_value()`'s save path, which matches by bare key
+   TEXT across the whole file with no section-scoping at all (confirmed
+   by reading `patch_yaml_value`'s own regex - `^\s*{key}:\s*...`, first
+   match wins). Renamed to `char_enabled`/`logo_enabled`/`gauge_enabled`/
+   `logo_depth_mm`/`label_depth_mm` in all 3 wing-family configs +
+   their `configure()` readers. Verified with a real round-trip test
+   (see below) that catches exactly this class of bug, not just eyeballed.
+
+**Audit against sibling machines/conventions** (per CLAUDE.md's own
+"every machine port gets an explicit audit pass" rule):
+- Entry points match the fleet convention exactly: `configure()`,
+  `_require_configured()`, `FullElement`/`ResinPrint`/`Additive`, all
+  accepting-but-ignoring `separation_mm`/`render_core_groove` (neither
+  concept exists for this form factor - same precedent Selectric already
+  set). `box_slug.py`'s `ResinSupport()`/`ResinPrint()` (real no-op
+  passthrough) matches `lib/helios.py`'s own established pattern for a
+  machine with zero resin-support geometry, including the matching
+  `RESIN_SUPPORT_UNAVAILABLE_NOTE` entries in `tune.py`.
+- `build.resin_support` is a real build-time toggle (`ResinPrint` vs
+  `FullElement` dispatch) for the wing family, NOT baked permanently into
+  the geometry the way v1's single `Resin_Support` variable was - a
+  deliberate structural improvement matching every other v4 machine's
+  own convention, explicitly called out in `config/type_slug.yaml`'s
+  comments rather than silently diverging from v1.
+  `build.minkowski_enabled` similarly defaults to `true` (a real drafted
+  build) on every new config even where v1's own literal default was
+  `Debug_No_Minkowski=true` (Oliver/Lumi) - explicitly noted in both
+  configs' comments as an intentional, fleet-consistency change, not a
+  silent divergence, per CLAUDE.md's "say so explicitly" rule.
+- Dead v1 customizer variables are called out in config comments, not
+  silently dropped or silently wired to a fake no-op parameter:
+  `Side_Hole_Offset` (declared, never referenced by `hole_coords`) and
+  `Lower_Wing_Angle` (declared for Oliver/Lumi, but both real wing-angle
+  cuts use `Upper_Wing_Angle` even for the "lower" cut - a real,
+  preserved v1 quirk, not a transcription choice made here).
+  TypeSlug.scad's own `SVG_Vogue_Enable` branch (a byte-for-byte
+  duplicate of its `SVG_Enable` branch, not the real Vogue mark) is
+  called out as dead/redundant leftover, not ported as a second toggle.
+- New `tune.py` "Slugs" `MACHINE_CATEGORIES` group added (4th column,
+  fully data-driven from the existing generic per-loop composer, no new
+  hardcoded-count literals to fix - this family has no keyboard grid at
+  all, so none of the "9 hardcoded row/column literals" class of bug
+  Mignon's port hit applies). Gauge Slug's tick-mark fields deliberately
+  named `"Ticks"` in `SECTIONS_BY_MACHINE`, NOT `"Gauge"` - the existing
+  `"Gauge"` section name means Blickensderfer/Postal's Shaft Gauge Test
+  build-target option (`_compose_build_tab`'s `has_gauge`/
+  `GaugeTestSet()` dispatch), which `gauge_slug.py` does not implement;
+  reusing that name would have wired a broken "Shaft Gauge" build-target
+  button into the Build tab.
+- No Layout tab (no `layout:` config section at all - `HAS_LAYOUT_TAB`
+  is naturally `False` via the existing `"rows" in layout` check, same
+  mechanism Selectric's own "no editable keyboard-layout concept"
+  already relies on - no new code needed). No Calibration tab either
+  (`CalibrationElement`/`CalibrationAdditive` not implemented for this
+  family, matching `spherical_machine.py`'s own explicit "deferred to a
+  follow-up pass" precedent, not a silent gap).
+
+**Verification performed:**
+- `generate.py` run for all 5 new configs, both `--no-minkowski` and a
+  REAL Minkowski build (the invariant `--no-minkowski` alone can't
+  verify) - every one watertight/winding_consistent/is_volume=True,
+  including Vogue Slug's real 2-piece SVG Minkowski draft and Type
+  Slug's real AR1.svg logo + struck text + loop combined build.
+  Bounding-box sanity-checked against each config's own real Body_Width/
+  Body_Length/Body_Height (caught the scad_transform bug above before
+  it could hide as a false-positive "watertight" pass).
+- `tune.py` headless-tested against SCRATCH copies only (never the real
+  master/running configs, per this file's own part-12 warning) -
+  `TuneApp` construction, `self.SECTIONS`/`self.FIELDS` contents, and a
+  real round-trip `patch_yaml_value()` pass over every field for all 5
+  machines (write each field's own current value back, re-parse, assert
+  identical) - this is what actually caught bug 3 above, not a visual
+  inspection.
+- Existing-config regression check (`bennett.yaml`, `selectric12.yaml`,
+  both `--no-minkowski`): still watertight/winding_consistent/is_volume=
+  True after this session's `scad_primitives.py`/`tune.py` edits (both
+  purely additive - a new `torus()` function, new dict entries/FIELDS
+  lists, no existing function or entry modified).
+
+Not done in this pass (no signal it's wanted, and matches Selectric's
+own precedent of deferring the same feature at first port):
+`CalibrationElement`/`CalibrationAdditive` for any of the 5 new
+machines.

--- a/v4/config/gauge_slug.yaml
+++ b/v4/config/gauge_slug.yaml
@@ -1,0 +1,137 @@
+# Gauge Slug - v1/Type Slugs/GaugeTypeSlugSlug.scad. The one REAL,
+# functional member of this family (see lib/gauge_slug.py's module
+# docstring): no struck character, no logo, just the wing body with a
+# two-row tick-hole ladder, meant to be installed on the real machine
+# and used to measure/calibrate typebar swing and alignment-cut
+# position directly. Shares lib/wing_slug.py's engine with
+# config/type_slug.yaml/vogue_slug.yaml - see that module's docstring
+# for the shared geometry pipeline and the v1-is-ground-truth callout.
+#
+# v1's own customizer block declares character/logo/draft-angle
+# variables (SVG_Enable=true, Lower_Char='e', Draft_Angle=60, ...) that
+# the real MakeSlug-equivalent body in GaugeTypeSlugSlug.scad NEVER
+# actually references (no SVG import, no text() call anywhere in that
+# file's real geometry - only the body hull, the typebar slot, the
+# copyright engraving, and the tick holes). character.enabled/
+# logo.enabled below are set to false to match what v1 ACTUALLY renders,
+# not its inert leftover customizer defaults - a real fidelity choice,
+# not a silent omission.
+
+machine: gauge_slug
+
+font:
+  # Unused (character.enabled/logo.enabled are both false) - present
+  # only because wing_slug._receive_config picks up every capital-
+  # leading global unconditionally, and configure()/Type Test both
+  # still read font.path/size_mm.
+  path: "/home/lchau/fonts/Library/Typewriter & Monospace/CMU Typewriter Text.ttf"
+  size_mm: 3.0
+  name: "CMU Typewriter Text"
+
+alignment:
+  mode: "center"
+  center_offset_mm: 0.0
+  left_offset_mm: 0.0
+  modified_left_chars: ""
+  modified_left_offset_mm: 0.0
+  modified_right_chars: ""
+  modified_right_offset_mm: 0.0
+
+character:
+  char_enabled: false            # GaugeTypeSlugSlug.scad's real body never calls text() - see this file's header comment
+  lower_char: "e"
+  upper_char: "E"
+
+logo:
+  logo_enabled: false             # GaugeTypeSlugSlug.scad's real body never imports an SVG either - see this file's header comment
+  svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/AR1.svg"
+  scale_mm_per_unit: 0.02
+  logo_depth_mm: 0.05
+  location_frac: 0.5
+  vogue_enabled: false
+  vogue_arrow_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-arrow.svg"
+  vogue_v_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-v.svg"
+
+label:
+  text: "© Leonard Chau 2023"          # v1 Copyright_Text (GaugeTypeSlugSlug.scad:63)
+  font_path: "/home/lchau/fonts/Library/Typewriter & Monospace/Courier Prime.ttf"  # v1 Copyright_Font "Courier Prime"
+  label_depth_mm: 0.1                          # v1 Copyright_Depth (:61)
+
+element:
+  body_width_mm: 2.75              # v1 Body_Width (:6)
+  body_length_mm: 12.0             # v1 Body_Length (:8)
+  body_height_mm: 5.0              # v1 Body_Height (:10)
+  face_thickness_mm: 0.5           # v1 Face_Thickness (:12)
+  face_radius_mm: 0.2              # v1 Face_Radius (:14)
+  wing_radius_mm: 2.0              # v1 Wing_Radius (:16)
+  platen_shift_motion_mm: 6.6      # unused (character.enabled: false) - v1 Platen_Shift_Motion (:18)
+  baselines_shift_motion_mm: 6.6   # unused - v1 Baselines_Shift_Motion (:20)
+  body_slot_width_mm: 0.93         # v1 Body_Slot_Width (:22)
+  wing_thickness_mm: 0.5           # v1 Wing_Thickness (:24)
+  aligning_cut_mm: 2.5             # unused - v1 Aligning_Cut (:26)
+  baseline_mm: 2.0                 # unused - v1 Baseline (:28)
+  platen_diameter_mm: 25.4         # unused - v1 Platen_Diameter (:30)
+  bottom_thickness_mm: 1.0         # v1 Bottom_Thickness (:32)
+  upper_wing_angle_deg: 20.0       # v1 Upper_Wing_Angle (:38)
+  lower_wing_angle_deg: 10.0       # v1 Lower_Wing_Angle (:40)
+  # GaugeTypeSlugSlug.scad has no Loop/Post/Side_Hole concept at all -
+  # every flag below is really off, not a placeholder default.
+  loop_enabled: false
+  loop_thickness_mm: 0.75
+  loop_diameter_mm: 2.75
+  loop_rotation_deg: 0.0
+  post_enabled: false
+  post_id_mm: 1.0
+  post_od_mm: 0.5
+  side_hole_enabled: false
+  side_hole_id_mm: 1.0
+  side_hole_height_frac: 0.2
+
+build:
+  flatness_tolerance_mm: 0.01
+  minkowski_enabled: true          # unused (character.enabled/logo.enabled both false, so no Minkowski sweep ever runs)
+  draft_angle_deg: 60.0            # unused - v1 Draft_Angle (:34)
+  engraving_depth_mm: 0.5          # unused - v1 Engraving_Depth (:36)
+  minkowski_multiplier: 1.6        # unused - v1 Minkowski_Multiplier (:68)
+  character_block_height_mm: 2.0   # unused
+  resin_support: false             # GaugeTypeSlugSlug.scad has no resin-support geometry at all
+  target: "element"
+
+quality:
+  corner_fn: 40           # v1 module-level $fn (:4), used by the base-face corner cylinders
+  wing_fn: 360
+  platen_fn: 360           # unused
+  minkowski_fn: 40          # unused
+  loop_fn: 360               # unused
+  loop_tube_fn: 32            # unused - see config/type_slug.yaml's matching comment
+  post_fn: 360                # unused
+  side_hole_fn: 360            # unused
+
+resin:
+  # Unused (build.resin_support is false) - present only because
+  # wing_slug._receive_config picks up every capital-leading global
+  # unconditionally.
+  resin_fn: 40
+  raft_thickness_mm: 2.0
+  wire_thickness_mm: 0.6
+  support_height_mm: 2.0
+  support_pitch_mm: 2.0
+
+gauge:
+  gauge_enabled: true
+  fine_pitch_mm: 0.5        # v1 `for (n=[0:.5:Body_Length])` (GaugeTypeSlugSlug.scad:104)
+  major_pitch_mm: 2.0       # v1 `for (n=[2:2:Body_Length])` (:109)
+  hole_d_mm: 0.5            # v1 both loops' cylinder(d=.5, ...) (:106,111)
+  fine_z_mm: -1.5           # v1 fine row's base_z (:105)
+  major_z_mm: -5.0          # v1 major row's base_z (:110)
+  hole_fn: 40               # v1 module-level $fn (:4) - these holes have no explicit $fn of their own
+
+output:
+  directory: "output"
+  stl_name: "gauge_slug_running.stl"
+
+type_test:
+  cpi: 10.0
+  lpi: 6.0
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/config/lumi_slug.yaml
+++ b/v4/config/lumi_slug.yaml
@@ -1,0 +1,82 @@
+# Lumi Slug - v1/Type Slugs/LumiSlug.scad, a pure novelty item (a
+# 4-character loop pendant - per the user's own framing, same as
+# config/oliver_slug.yaml). Shares lib/box_slug.py's engine with
+# config/oliver_slug.yaml - see that module's docstring for the shared
+# geometry pipeline and the v1-is-ground-truth callout.
+
+machine: lumi_slug
+
+font:
+  path: "/home/lchau/fonts/Library/Typewriter & Monospace/Erica Type.ttf"
+  size_mm: 3.05           # v1 Type_Size (LumiSlug.scad:25)
+  name: "Erica Type"
+
+alignment:
+  mode: "center"
+  center_offset_mm: 0.0
+  left_offset_mm: 0.0
+  modified_left_chars: ""
+  modified_left_offset_mm: 0.0
+  modified_right_chars: ""
+  modified_right_offset_mm: 0.0
+
+character:
+  # Bottom to top: Figure_Char, Lower_Char, Upper_Char, fun_char (v1:22-28).
+  chars: ["T", "N", "U", "C"]
+  baseline_mm: 1.0                 # v1 Baseline (:13)
+  baselines_shift_motion_mm: 7.1   # v1 Baselines_Shift_Motion (:9)
+
+element:
+  body_width_mm: 3.2               # v1 Body_Width (:5)
+  body_length_mm: 26.0             # v1 Body_Length (:6)
+  body_height_mm: 5.0              # v1 Body_Height (:7)
+  platen_shift_motion_mm: 7.1      # v1 Platen_Shift_Motion (:8)
+  body_slot_width_mm: 1.2          # v1 Body_Slot_Width (:10)
+  wing_thickness_mm: 1.0           # v1 Wing_Thickness = (Body_Width-Body_Slot_Width)/2 (:11) - explicit value, not derived in code
+  aligning_cut_mm: 1.5             # v1 Aligning_Cut (:12)
+  platen_diameter_mm: 25.4         # v1 Platen_Diameter (:14)
+  bottom_thickness_mm: 1.0         # v1 Bottom_Thickness (:15)
+  # See config/oliver_slug.yaml's matching comment - Lower_Wing_Angle is
+  # dead in the real source, only Upper_Wing_Angle (here 0, commented
+  # out in v1 same as Oliver) is real.
+  upper_wing_angle_deg: 0.0
+  loop_enabled: true               # v1 Loop (:30)
+  loop_thickness_mm: 0.9           # v1 Loop_Thickness (:31)
+  loop_diameter_mm: 3.2            # v1 Loop_Diameter = Body_Width (:32)
+  loop_rotation_deg: 0.0           # v1 Loop_Rotation (:33)
+
+build:
+  flatness_tolerance_mm: 0.01
+  # See config/oliver_slug.yaml's matching comment - v1's own literal
+  # default is Debug_No_Minkowski=true; v4 intentionally defaults to a
+  # real drafted build here instead, matching every sibling config.
+  minkowski_enabled: true
+  draft_angle_deg: 60.0            # v1 Draft_Angle (:16)
+  engraving_depth_mm: 0.7          # v1 Engraving_Depth (:18)
+  minkowski_multiplier: 1.5        # v1's hardcoded cone height factor (LumiSlug.scad:76-77 - "Engraving_Depth*1.5")
+  character_block_height_mm: 2.0   # v1's hardcoded linear_extrude(2) (:48,50,53,56) - construction margin, config-driven per CLAUDE.md
+  resin_support: false             # LumiSlug.scad has no resin-support geometry at all
+  target: "element"
+
+quality:
+  minkowski_fn: 40         # v1 module-level $fn=40 (:4) - the draft cone has no explicit $fn of its own
+  platen_fn: 360             # v1 explicit $fn=360 on the platen cutout cylinders (:64,66,68,70)
+  loop_fn: 360                # v1 explicit $fn=360 on the loop's rotate_extrude sweep (:116,118)
+  loop_tube_fn: 32             # v1 ALSO uses $fn=360 for the loop's tube cross-section (same lines) - reduced here, see scad_primitives.torus()'s docstring for the measured 100x facet-count blow-up this avoids
+
+resin:
+  # Unused (build.resin_support is false) - present only because
+  # tune.py's Resin tab is shown unconditionally for every machine, same
+  # convention lib/helios.py's own always-declared-but-dead resin
+  # section establishes.
+  resin_fn: 40
+
+output:
+  directory: "output"
+  stl_name: "lumi_slug_running.stl"
+
+type_test:
+  cpi: 10.0
+  lpi: 6.0
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/config/oliver_slug.yaml
+++ b/v4/config/oliver_slug.yaml
@@ -1,0 +1,96 @@
+# Oliver Slug - v1/Type Slugs/OliverSlug.scad, a replica modeled after a
+# real Oliver typewriter type slug (novelty/reference, not a functional
+# part - per the user's own framing). Shares lib/box_slug.py's engine
+# with config/lumi_slug.yaml - see that module's docstring for the
+# shared geometry pipeline and the v1-is-ground-truth callout.
+
+machine: oliver_slug
+
+font:
+  path: "/home/lchau/fonts/Library/Typewriter & Monospace/Erica Type.ttf"
+  size_mm: 3.05           # v1 Type_Size (OliverSlug.scad:25)
+  name: "Erica Type"
+
+alignment:
+  # v1 hardcodes text()'s halign="center" with no left mode/modified-char
+  # concept at all - these defaults reproduce that exactly; real, usable
+  # knobs are exposed anyway since the Font & Alignment tab is shared UI.
+  mode: "center"
+  center_offset_mm: 0.0
+  left_offset_mm: 0.0
+  modified_left_chars: ""
+  modified_left_offset_mm: 0.0
+  modified_right_chars: ""
+  modified_right_offset_mm: 0.0
+
+character:
+  # Bottom to top: Figure_Char, Lower_Char, Upper_Char (v1:22-24) -
+  # config-driven list length, not a fixed triple (lib/lumi_slug.py's
+  # config has a 4th entry).
+  chars: ["3", "e", "E"]
+  baseline_mm: 1.0                 # v1 Baseline (:13)
+  baselines_shift_motion_mm: 7.1   # v1 Baselines_Shift_Motion (:9)
+
+element:
+  body_width_mm: 3.2               # v1 Body_Width (:5)
+  body_length_mm: 18.2             # v1 Body_Length (:6)
+  body_height_mm: 5.0              # v1 Body_Height (:7)
+  platen_shift_motion_mm: 7.1      # v1 Platen_Shift_Motion (:8)
+  body_slot_width_mm: 1.2          # v1 Body_Slot_Width (:10)
+  wing_thickness_mm: 1.0           # v1 Wing_Thickness = (Body_Width-Body_Slot_Width)/2 (:11) - explicit value, not derived in code
+  aligning_cut_mm: 1.5             # v1 Aligning_Cut (:12)
+  platen_diameter_mm: 25.4         # v1 Platen_Diameter (:14)
+  bottom_thickness_mm: 1.0         # v1 Bottom_Thickness (:15)
+  # v1's own Upper_Wing_Angle/Lower_Wing_Angle (:19-20) are both
+  # commented down to 0 ("// 12;//gamma" / "// 10;//roh") - AND
+  # Lower_Wing_Angle is never referenced anywhere in the real geometry
+  # even when non-zero (both wing-angle cuts use Upper_Wing_Angle - see
+  # lib/box_slug.py's module docstring) - so only one real angle exists
+  # here, not ported as a separate dead key.
+  upper_wing_angle_deg: 0.0
+  loop_enabled: false              # OliverSlug.scad has no Loop concept at all
+  loop_thickness_mm: 0.75
+  loop_diameter_mm: 3.2
+  loop_rotation_deg: 0.0
+
+build:
+  flatness_tolerance_mm: 0.01
+  # v1's own literal default is Debug_No_Minkowski=true (fast/undrafted
+  # preview - OliverSlug.scad is a single-render script, not a
+  # Customizer project with a saved "real" preset the way TypeSlug.scad
+  # has). v4 intentionally resolves this differently: true here, so
+  # config's build.minkowski_enabled means the same thing (the real,
+  # final drafted output) on every v4 machine, matching every sibling
+  # config's own default - a deliberate, noted change, not a silent
+  # divergence (v1's literal default is still reachable via
+  # --no-minkowski).
+  minkowski_enabled: true
+  draft_angle_deg: 60.0            # v1 Draft_Angle (:16)
+  engraving_depth_mm: 0.7          # v1 Engraving_Depth (:18)
+  minkowski_multiplier: 1.5        # v1's hardcoded cone height factor (OliverSlug.scad:63-64 - "Engraving_Depth*1.5", not a customizable variable in v1, still config-driven here per CLAUDE.md)
+  character_block_height_mm: 2.0   # v1's hardcoded linear_extrude(2) (:40,42,45) - construction margin, config-driven per CLAUDE.md
+  resin_support: false             # OliverSlug.scad has no resin-support geometry at all
+  target: "element"
+
+quality:
+  minkowski_fn: 40         # v1 module-level $fn=40 (:4) - the draft cone has no explicit $fn of its own
+  platen_fn: 360             # v1 explicit $fn=360 on the platen cutout cylinders (:53,55,57)
+  loop_fn: 360                # unused (element.loop_enabled: false)
+  loop_tube_fn: 32             # unused - see config/type_slug.yaml's matching comment
+
+resin:
+  # Unused (build.resin_support is false) - present only because
+  # tune.py's Resin tab is shown unconditionally for every machine, same
+  # convention lib/helios.py's own always-declared-but-dead resin
+  # section establishes (see tune.py's RESIN_FIELDS_HELIOS).
+  resin_fn: 40
+
+output:
+  directory: "output"
+  stl_name: "oliver_slug_running.stl"
+
+type_test:
+  cpi: 10.0
+  lpi: 6.0
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/config/type_slug.yaml
+++ b/v4/config/type_slug.yaml
@@ -1,0 +1,147 @@
+# Generic Type Slug - v1/Type Slugs/TypeSlug.scad's own "CMU Typewriter
+# Text" customizer preset (v1/Type Slugs/TypeSlug.json). Novelty/
+# reference replica, not a functional typewriter part - see
+# lib/wing_slug.py's module docstring for the shared wing-body engine
+# this and config/vogue_slug.yaml/gauge_slug.yaml all drive. Ground
+# truth is v1 (this family was never carried into v2), cross-referenced
+# by v1 line number below, same convention v2 line numbers get
+# elsewhere.
+
+machine: type_slug
+
+font:
+  path: "/home/lchau/fonts/Library/Typewriter & Monospace/CMU Typewriter Text.ttf"
+  size_mm: 3.3           # v1 Type_Size ("CMU Typewriter Text" preset)
+  name: "CMU Typewriter Text"
+
+alignment:
+  # v1 hardcodes text()'s halign="center" with no left mode/modified-char
+  # concept at all (unlike the cylinder-family machines) - these defaults
+  # reproduce that exactly; real, usable knobs are exposed anyway since
+  # the Font & Alignment tab is shared UI (see lib/wing_slug.py's
+  # DraftText() - alignment_x_offset is a real call here, not decorative).
+  mode: "center"
+  center_offset_mm: 0.0
+  left_offset_mm: 0.0
+  modified_left_chars: ""
+  modified_left_offset_mm: 0.0
+  modified_right_chars: ""
+  modified_right_offset_mm: 0.0
+
+character:
+  char_enabled: true
+  lower_char: "e"          # v1 Lower_Char (TypeSlug.scad:20)
+  upper_char: "E"           # v1 Upper_Char (TypeSlug.scad:22)
+
+logo:
+  # v1's real generic-logo preset (SVG_Enable=true, SVG_File="AR1.svg" -
+  # TypeSlug.json's "CMU Typewriter Text" set). scale_mm_per_unit is a
+  # v4-only knob replacing v1's SVG_Scale=1/40*SVG_Size - see
+  # lib/svg_import.py's module docstring for why v4 doesn't reproduce
+  # OpenSCAD's own px/DPI SVG-import scaling; tuned empirically here to
+  # give AR1.svg a ~2mm span (matching v1's own "SVG_Size=2" naming),
+  # not derived from v1's formula.
+  logo_enabled: true
+  svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/AR1.svg"
+  scale_mm_per_unit: 0.02
+  logo_depth_mm: 0.05             # v1 SVG_Depth
+  location_frac: 0.55        # v1 SVG_Location ("CMU Typewriter Text" preset)
+  # TypeSlug.scad's OWN "SVG_Vogue_Enable" branch (lines 147-157) is a
+  # byte-for-byte duplicate of its SVG_Enable branch above (same
+  # SVG_File, not the real vogue-foundry-*.svg files) - dead/redundant
+  # leftover from when VogueSlug.scad was forked off of it, not a real
+  # second feature - see lib/wing_slug.py's module docstring. Not ported
+  # as a second toggle; vogue_enabled here always stays false for this
+  # machine (config/vogue_slug.yaml is where the REAL 2-piece mark
+  # lives). vogue_arrow_svg_file/vogue_v_svg_file still need real paths
+  # even though unused (wing_slug._receive_config picks up every
+  # capital-leading global unconditionally).
+  vogue_enabled: false
+  vogue_arrow_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-arrow.svg"
+  vogue_v_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-v.svg"
+
+label:
+  text: "© Leonard Chau 2023"          # v1 Copyright_Text (TypeSlug.scad:44)
+  font_path: "/home/lchau/fonts/Library/Typewriter & Monospace/Courier Prime.ttf"  # v1 Copyright_Font "Courier Prime"
+  label_depth_mm: 0.1                          # v1 Copyright_Depth
+
+element:
+  body_width_mm: 2.75              # v1 Body_Width (TypeSlug.scad:52)
+  body_length_mm: 12.0             # v1 Body_Length (:54)
+  body_height_mm: 5.0              # v1 Body_Height (:56)
+  face_thickness_mm: 0.5           # v1 Face_Thickness (:58)
+  face_radius_mm: 0.2              # v1 Face_Radius (:60)
+  wing_radius_mm: 2.0              # v1 Wing_Radius (:62)
+  platen_shift_motion_mm: 6.6      # v1 Platen_Shift_Motion (:64)
+  baselines_shift_motion_mm: 6.6   # v1 Baselines_Shift_Motion (:66)
+  body_slot_width_mm: 0.93         # v1 Body_Slot_Width (:68)
+  wing_thickness_mm: 0.5           # v1 Wing_Thickness (:70)
+  aligning_cut_mm: 2.5             # v1 Aligning_Cut - "CMU Typewriter Text" preset value (v1 default at :72 is 3.25)
+  baseline_mm: 2.0                 # v1 Baseline (:74)
+  platen_diameter_mm: 25.4         # v1 Platen_Diameter (:76)
+  bottom_thickness_mm: 1.0         # v1 Bottom_Thickness (:78)
+  upper_wing_angle_deg: 20.0       # v1 Upper_Wing_Angle (:16)
+  lower_wing_angle_deg: 10.0       # v1 Lower_Wing_Angle (:18)
+  loop_enabled: true               # v1 Loop (:88)
+  loop_thickness_mm: 0.75          # v1 Loop_Thickness (:89)
+  loop_diameter_mm: 2.75           # v1 Loop_Diameter = Body_Width by default (:90)
+  loop_rotation_deg: 0.0           # v1 Loop_Rotation (:91)
+  post_enabled: false              # v1 Post (:94)
+  post_id_mm: 1.0                  # v1 Post_ID (:95)
+  post_od_mm: 0.5                  # v1 Post_OD (:96)
+  side_hole_enabled: false         # v1 Side_Hole (:99)
+  # v1 Side_Hole_Offset (:100) is declared but never referenced by
+  # hole_coords (:106) - dead in the real source, not ported (see
+  # lib/wing_slug.py's SideHole()).
+  side_hole_id_mm: 1.0             # v1 Side_Hole_ID (:101)
+  side_hole_height_frac: 0.2       # v1 Side_Hole_Height (:102)
+
+build:
+  flatness_tolerance_mm: 0.01
+  minkowski_enabled: true          # v1 !Debug_No_Minkowski ("CMU Typewriter Text" preset: false)
+  draft_angle_deg: 60.0            # v1 Draft_Angle (:12)
+  engraving_depth_mm: 0.5          # v1 Engraving_Depth (:14)
+  minkowski_multiplier: 1.6        # v1 Minkowski_Multiplier (:48)
+  character_block_height_mm: 2.0   # v1's hardcoded linear_extrude(2) (e.g. :163,165) - construction margin, config-driven per CLAUDE.md
+  resin_support: true              # v1 Resin_Support (:81) - now a build-time toggle (ResinPrint vs FullElement), see lib/wing_slug.py's module docstring
+  target: "element"
+
+quality:
+  corner_fn: 40          # v1 module-level $fn=40 (:5), used by the base-face corner cylinders
+  wing_fn: 360            # v1 explicit $fn=360 on the wing cylinders (e.g. :130)
+  platen_fn: 360           # v1 explicit $fn=360 on the platen cutout cylinders (:172,174)
+  minkowski_fn: 40          # v1 draft cone has no explicit $fn - inherits the module-level default (:5)
+  loop_fn: 360               # v1 explicit $fn=360 on the loop's rotate_extrude sweep (:250)
+  loop_tube_fn: 32            # v1 ALSO uses $fn=360 for the loop's tube cross-section (same line) - reduced here, see scad_primitives.torus()'s docstring for the measured 100x facet-count blow-up this avoids
+  post_fn: 360                # Post has no explicit $fn in v1 either - inherits the module-level default; kept at 360 to stay smooth since it's a real printed boss when enabled
+  side_hole_fn: 360            # v1 explicit $fn=360 on the side-hole cylinder (:284)
+
+resin:
+  resin_fn: 40             # v1's resin support cylinders/spheres have no explicit $fn - inherit the module-level default (:5)
+  raft_thickness_mm: 2.0   # v1 Raft_Thickness (:82)
+  wire_thickness_mm: 0.6   # v1 Wire_Thickness (:83)
+  support_height_mm: 2.0   # v1 Support_Height (:84)
+  support_pitch_mm: 2.0    # v1 Support_Pitch (:85)
+
+# Gauge (the tick-mark measuring ladder) is real geometry only for
+# gauge_slug - see config/gauge_slug.yaml. Present here (disabled) only
+# because wing_slug._receive_config picks up every capital-leading
+# global unconditionally, same reasoning as logo.vogue_* above.
+gauge:
+  gauge_enabled: false
+  fine_pitch_mm: 0.5
+  major_pitch_mm: 2.0
+  hole_d_mm: 0.5
+  fine_z_mm: -1.5
+  major_z_mm: -5.0
+  hole_fn: 40
+
+output:
+  directory: "output"
+  stl_name: "type_slug_running.stl"
+
+type_test:
+  cpi: 10.0
+  lpi: 6.0
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/config/vogue_slug.yaml
+++ b/v4/config/vogue_slug.yaml
@@ -35,18 +35,26 @@ character:
 logo:
   logo_enabled: false            # v1 SVG_Enable ("True_Vogue" preset: false - the generic AR1 logo isn't used here)
   svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/AR1.svg"
-  scale_mm_per_unit: 0.02
+  # scale_mm_per_unit is shared between the (unused, off) generic AR1
+  # logo above and the real Vogue Foundry mark below - the value here is
+  # tuned for the LATTER (0.0025 gives the combined arrow+V mark a
+  # ~1.6x1.6mm footprint, comfortably inside this config's 2.6mm body
+  # width). config/type_slug.yaml's own 0.02 is unrelated - tuned
+  # separately for AR1.svg's own, much larger viewBox - don't copy that
+  # value here (a real bug once: this field was accidentally left at
+  # 0.02, giving an ~8x oversized, body-engulfing mark before this
+  # comment/fix).
+  scale_mm_per_unit: 0.0025
   logo_depth_mm: 0.05             # v1 SVG_Depth
   location_frac: 0.5         # v1 SVG_Location ("True_Vogue" preset)
   # The real 2-piece Vogue Foundry mark (VogueSlug.scad:109-126) - always
   # on for this machine (v1 SVG_Vogue_Enable=true, VogueSlug.scad:51, not
   # exposed as a per-preset override in the real Customizer JSON either -
-  # it's the whole point of this file). scale_mm_per_unit reuses logo.
-  # scale_mm_per_unit above (v1's own SVG_V1_Scale is likewise a single
-  # shared scale for both the arrow and V pieces, VogueSlug.scad:54-56) -
-  # tuned empirically for a similarly small, legible foundry mark (see
+  # it's the whole point of this file). Uses the SAME scale_mm_per_unit
+  # above (v1's own SVG_V1_Scale is likewise a single shared scale for
+  # both the arrow and V pieces, VogueSlug.scad:54-56) - see
   # lib/svg_import.py's module docstring for why v4 doesn't reproduce
-  # OpenSCAD's own px/DPI SVG-import scaling).
+  # OpenSCAD's own px/DPI SVG-import scaling.
   vogue_enabled: true
   vogue_arrow_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-arrow.svg"
   vogue_v_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-v.svg"

--- a/v4/config/vogue_slug.yaml
+++ b/v4/config/vogue_slug.yaml
@@ -1,0 +1,142 @@
+# Vogue Slug - v1/Type Slugs/VogueSlug.scad's own "True_Vogue" customizer
+# preset (v1/Type Slugs/VogueSlug.json), the faithful replica modeled
+# from real drawings, carrying the real 2-piece "Vogue Foundry" mark
+# (vogue-foundry-arrow.svg + vogue-foundry-v.svg). Shares
+# lib/wing_slug.py's engine with config/type_slug.yaml/gauge_slug.yaml -
+# see that module's docstring for the shared geometry pipeline and the
+# v1-is-ground-truth callout. VogueSlug.scad itself has no resin-
+# support/loop/post/side-hole concept at all (unlike TypeSlug.scad) -
+# every element.*_enabled/build.resin_support flag below is really off,
+# not a placeholder.
+
+machine: vogue_slug
+
+font:
+  # The real "True_Vogue" font Leo built for this replica (confirmed via
+  # its own embedded family name, not a filename guess).
+  path: "/home/lchau/Downloads/True_Vogue_final(1)_really_THIS_ONE.ttf"
+  size_mm: 3.15           # v1 Type_Size ("True_Vogue" preset)
+  name: "True_Vogue"
+
+alignment:
+  mode: "center"
+  center_offset_mm: 0.0
+  left_offset_mm: 0.0
+  modified_left_chars: ""
+  modified_left_offset_mm: 0.0
+  modified_right_chars: ""
+  modified_right_offset_mm: 0.0
+
+character:
+  char_enabled: true
+  lower_char: "e"          # v1 Lower_Char (VogueSlug.scad:42)
+  upper_char: "E"           # v1 Upper_Char (VogueSlug.scad:44)
+
+logo:
+  logo_enabled: false            # v1 SVG_Enable ("True_Vogue" preset: false - the generic AR1 logo isn't used here)
+  svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/AR1.svg"
+  scale_mm_per_unit: 0.02
+  logo_depth_mm: 0.05             # v1 SVG_Depth
+  location_frac: 0.5         # v1 SVG_Location ("True_Vogue" preset)
+  # The real 2-piece Vogue Foundry mark (VogueSlug.scad:109-126) - always
+  # on for this machine (v1 SVG_Vogue_Enable=true, VogueSlug.scad:51, not
+  # exposed as a per-preset override in the real Customizer JSON either -
+  # it's the whole point of this file). scale_mm_per_unit reuses logo.
+  # scale_mm_per_unit above (v1's own SVG_V1_Scale is likewise a single
+  # shared scale for both the arrow and V pieces, VogueSlug.scad:54-56) -
+  # tuned empirically for a similarly small, legible foundry mark (see
+  # lib/svg_import.py's module docstring for why v4 doesn't reproduce
+  # OpenSCAD's own px/DPI SVG-import scaling).
+  vogue_enabled: true
+  vogue_arrow_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-arrow.svg"
+  vogue_v_svg_file: "/home/lchau/github/Type-Elements/v1/Type Slugs/vogue-foundry-v.svg"
+
+label:
+  text: "☺ Leonard Chau 2023"          # v1 Copyright_Text (VogueSlug.scad:66)
+  # v1 Copyright_Font "Courier New" (VogueSlug.scad:68) isn't installed
+  # here - substituted with Courier Prime, the same metric-compatible
+  # typewriter-style substitute config/postal.yaml's FreeMono swap
+  # already establishes as this fleet's convention for a missing font.
+  font_path: "/home/lchau/fonts/Library/Typewriter & Monospace/Courier Prime.ttf"
+  label_depth_mm: 0.1                          # v1 Copyright_Depth
+
+element:
+  body_width_mm: 2.6               # v1 Body_Width ("True_Vogue" preset)
+  body_length_mm: 11.75            # v1 Body_Length ("True_Vogue" preset)
+  body_height_mm: 5.5              # v1 Body_Height ("True_Vogue" preset)
+  face_thickness_mm: 0.5           # v1 Face_Thickness
+  face_radius_mm: 0.2              # v1 Face_Radius
+  wing_radius_mm: 2.0              # v1 Wing_Radius
+  platen_shift_motion_mm: 6.6      # v1 Platen_Shift_Motion
+  baselines_shift_motion_mm: 6.6   # v1 Baselines_Shift_Motion
+  body_slot_width_mm: 1.0          # v1 Body_Slot_Width ("True_Vogue" preset)
+  wing_thickness_mm: 0.5           # v1 Wing_Thickness
+  aligning_cut_mm: 2.5             # v1 Aligning_Cut ("True_Vogue" preset)
+  baseline_mm: 0.7                 # v1 Baseline ("True_Vogue" preset)
+  platen_diameter_mm: 25.4         # v1 Platen_Diameter
+  bottom_thickness_mm: 1.0         # v1 Bottom_Thickness
+  upper_wing_angle_deg: 10.0       # v1 Upper_Wing_Angle ("True_Vogue" preset)
+  lower_wing_angle_deg: 10.0       # v1 Lower_Wing_Angle
+  # VogueSlug.scad has no Loop/Post/Side_Hole concept at all (see this
+  # file's own header comment) - every flag below is really off, not a
+  # placeholder default.
+  loop_enabled: false
+  loop_thickness_mm: 0.75
+  loop_diameter_mm: 2.6
+  loop_rotation_deg: 0.0
+  post_enabled: false
+  post_id_mm: 1.0
+  post_od_mm: 0.5
+  side_hole_enabled: false
+  side_hole_id_mm: 1.0
+  side_hole_height_frac: 0.2
+
+build:
+  flatness_tolerance_mm: 0.01
+  minkowski_enabled: true          # v1 !Debug_No_Minkowski ("True_Vogue" preset: false)
+  draft_angle_deg: 60.0            # v1 Draft_Angle
+  engraving_depth_mm: 0.5          # v1 Engraving_Depth
+  minkowski_multiplier: 1.6        # v1 Minkowski_Multiplier
+  character_block_height_mm: 2.0   # v1's hardcoded linear_extrude(2) - construction margin, config-driven per CLAUDE.md
+  resin_support: false             # VogueSlug.scad has no resin-support geometry at all
+  target: "element"
+
+quality:
+  corner_fn: 40
+  wing_fn: 360
+  platen_fn: 360
+  minkowski_fn: 40
+  loop_fn: 360
+  loop_tube_fn: 32           # unused (element.loop_enabled: false) - see config/type_slug.yaml's matching comment
+  post_fn: 360
+  side_hole_fn: 360
+
+resin:
+  # Unused (element.loop/post/side_hole are all off and build.
+  # resin_support is false for this machine) - present only because
+  # wing_slug._receive_config picks up every capital-leading global
+  # unconditionally, same reasoning as logo.vogue_* fields elsewhere.
+  resin_fn: 40
+  raft_thickness_mm: 2.0
+  wire_thickness_mm: 0.6
+  support_height_mm: 2.0
+  support_pitch_mm: 2.0
+
+gauge:
+  gauge_enabled: false
+  fine_pitch_mm: 0.5
+  major_pitch_mm: 2.0
+  hole_d_mm: 0.5
+  fine_z_mm: -1.5
+  major_z_mm: -5.0
+  hole_fn: 40
+
+output:
+  directory: "output"
+  stl_name: "vogue_slug_running.stl"
+
+type_test:
+  cpi: 10.0
+  lpi: 6.0
+  text: |-
+    Sphinx of black quartz, judge my vow

--- a/v4/lib/box_slug.py
+++ b/v4/lib/box_slug.py
@@ -1,0 +1,299 @@
+"""
+Shared "box body" type-slug engine - lib/oliver_slug.py (Oliver
+typewriter slug replica) and lib/lumi_slug.py (novelty pendant) both
+configure this module and share everything here, same "shared engine +
+thin per-variant module" pattern lib/wing_slug.py uses for lib/
+type_slug.py/vogue_slug.py/gauge_slug.py.
+
+Ground truth is v1 (v1/Type Slugs/OliverSlug.scad, v1/Type Slugs/
+LumiSlug.scad), not v2 - see lib/wing_slug.py's module docstring for why
+(this whole family was never carried into v2). A genuinely different
+form factor from the wing body family despite being another "type slug"
+- a plain rectangular prism body (no rounded hull/wing-radius cylinders),
+straight polygon-cut wing tapers instead of a curved hull silhouette,
+N stacked struck characters (3 for Oliver, 4 for Lumi - config-driven
+list, not a fixed pair), N platen cutout cylinders to match, no resin
+support at all, no SVG logo, no post/side-hole. Verified function-by-
+function against both real v1 sources before writing anything, per
+CLAUDE.md's "diff against source first" rule (adapted to v1 here).
+
+Function-by-function relationship to v1/Type Slugs/OliverSlug.scad
+(lines 29-98 - LumiSlug.scad's own structure is byte-identical except
+for its extra 4th character and the trailing Loop union, both ported
+as config-driven options here, not separate code paths):
+  - BodyBox() -> "Create Solid Type Body" (32-33).
+  - DraftText() -> "Create Draft Angle Text" (35-59) - N stacked struck
+    characters (character.chars, config-driven length), same shift-then-
+    mirror-then-platen-cut-then-Minkowski-sum construction as lib/
+    wing_slug.py's own DraftText(), but this family's OWN real cone
+    formula (h=Engraving_Depth*1.5, a HARDCODED 1.5 in v1 - not the
+    customizable Minkowski_Multiplier the wing family has - still routed
+    through build.minkowski_multiplier here since it's a real geometry-
+    affecting constant either way, just a different real default per
+    CLAUDE.md's "keep the numeric constant in that machine's YAML"
+    rule) and N platen cylinders, not the wing family's fixed pair.
+  - _typebar_and_wing_taper_cuts() -> "Cut Typebar Slot"/"Cut Wing
+    Tapers" (68-82), both real children of one shared rotate([-90,0,0])
+    group - built here as 3 local (pre-rotate) meshes unioned first, one
+    rotate applied once (linear op, safe to batch - same simplification
+    lib/wing_slug.py's EnvelopeHull already makes for its own nested
+    hull()s).
+  - _wing_angle_cut() -> "Cut Upper/Lower Wing Angle" (85-95) - TWO
+    separate top-level cuts, both real. v1's own Lower_Wing_Angle
+    variable (declared line 20) is NEVER referenced by either cut - both
+    literally use Upper_Wing_Angle (line 89's own polygon() call, and
+    line 95's IDENTICAL polygon() call) - a real, preserved v1 quirk,
+    not a transcription choice made here. Not ported as a usable
+    config key at all (dead in the real source), per CLAUDE.md's
+    "say so explicitly instead of silently diverging" convention -
+    see config/oliver_slug.yaml's/lumi_slug.yaml's own comment.
+  - Loop() -> LumiSlug.scad's own trailing "if (Loop==true)" block
+    (113-120) - byte-identical recipe to lib/wing_slug.py's Loop(),
+    both now built via the shared scad_primitives.torus() (see that
+    function's own docstring). OliverSlug.scad has no Loop concept at
+    all - element.loop_enabled: false for oliver_slug.yaml is the real
+    behavior, not a placeholder.
+  - No resin support anywhere in either real v1 source (unlike the wing
+    family) - ResinPrint() here is a real no-op passthrough to
+    FullElement(), same pattern lib/helios.py's own ResinPrint()
+    establishes for a machine with no resin-support geometry modeled
+    (see tune.py's RESIN_SUPPORT_UNAVAILABLE_NOTE for the matching UI
+    callout, extended here for oliver_slug/lumi_slug).
+
+Assembly order for the Loop, faithfully preserved even though it looks
+almost like lib/wing_slug.py's own Loop handling: LumiSlug.scad's Loop
+is added AFTER (outside) the difference() that applies the typebar-
+slot/wing-taper/wing-angle cuts (`union(){ difference(){...cuts...};
+loop; }`), so it is NEVER itself subject to any of those cuts - a real,
+different assembly order from lib/wing_slug.py's Loop (which sits
+INSIDE the union that later gets its own final typebar-slot/copyright/
+hole cuts applied, physically a no-op there since Loop sits well clear
+of those cutters, but structurally different source code, ported as
+such rather than unified).
+"""
+
+import numpy as np
+import trimesh
+from manifold3d import Manifold
+from shapely.geometry import Polygon as ShapelyPolygon
+
+from glyph_poc import (get_glyph_contours_and_advance, classify_and_triangulate,
+                        alignment_x_offset, em_to_mm_scale, load_font_face)
+import scad_primitives as sp
+import build_log
+
+_active_machine = None
+
+
+def _receive_config(source_globals, machine_name):
+    global _active_machine
+    if _active_machine not in (None, machine_name):
+        raise RuntimeError(
+            f"box_slug already configured for {_active_machine!r}; "
+            f"cannot reconfigure for {machine_name!r} in the same process")
+    _active_machine = machine_name
+    globals().update({k: v for k, v in source_globals.items() if k[:1].isupper() or k == "z"})
+
+
+def _require_configured():
+    if _active_machine is None:
+        raise RuntimeError("call <machine>.configure(config_path) before using this module")
+
+
+# ------------------------------------------------------------------ Body
+
+def BodyBox():
+    """"Create Solid Type Body" (v1:32-33)."""
+    _require_configured()
+    return sp.box_centered([Body_Width, Body_Length, Body_Height],
+                            [0.0, Body_Length / 2.0, -Body_Height / 2.0])
+
+
+# -------------------------------------------------------------- Draft text
+
+def _draft_cone(cone_segments=None, draft_angle_deg=None):
+    """v1's draft cone (e.g. :62-64): cylinder(h=Engraving_Depth*1.5,
+    r1=sin(Draft_Angle)*that height, r2=0) - same "widen toward the
+    root" construction as lib/wing_slug.py's own _draft_cone(), same
+    real sin(Draft_Angle) formula, just this family's own 1.5 multiplier
+    (build.minkowski_multiplier - see module docstring)."""
+    fn = Minkowski_Fn if cone_segments is None else cone_segments
+    angle = Draft_Angle if draft_angle_deg is None else draft_angle_deg
+    h = Engraving_Depth * Minkowski_Multiplier
+    r1 = np.sin(np.radians(angle)) * h
+    cone = Manifold.cylinder(h, r1, 0.0, circular_segments=fn)
+    return cone.translate([0, 0, -h])
+
+
+def _platen_cylinders(platen_fn=None):
+    """N platen cutout cylinders (v1:50-58 - 3 for Oliver, 4 for Lumi),
+    stacked at Aligning_Cut + n*Platen_Shift_Motion. Built in local
+    (pre-rotate) space then rotate([0,90,0])+translate([0,Aligning_Cut,
+    Engraving_Depth+Platen_Diameter/2]) applied to the whole stack -
+    same translate-outer/rotate-inner order as lib/wing_slug.py's own
+    _platen_cyl_pair (v1:51-58 - `translate(...) rotate(...){cylinder();
+    translate() cylinder(); translate() cylinder();}`)."""
+    fn = Platen_Fn if platen_fn is None else platen_fn
+    base = trimesh.creation.cylinder(radius=Platen_Diameter / 2.0, height=Body_Width, sections=fn)
+    cyls = [sp.translate(base.copy(), [0, n * Platen_Shift_Motion, 0]) for n in range(len(Character_Chars))]
+    return [sp.scad_transform(m, ("translate", [0, Aligning_Cut, Engraving_Depth + Platen_Diameter / 2.0]),
+                               ("rotate", [0, 90, 0]))
+            for m in cyls]
+
+
+def _align_kwargs():
+    return dict(mode=Align_Mode, center_offset_mm=Align_Center_Offset_Mm,
+                left_offset_mm=Align_Left_Offset_Mm,
+                modified_left_chars=Align_Modified_Left_Chars,
+                modified_left_offset_mm=Align_Modified_Left_Offset_Mm,
+                modified_right_chars=Align_Modified_Right_Chars,
+                modified_right_offset_mm=Align_Modified_Right_Offset_Mm)
+
+
+def DraftText(flatness_tolerance_mm=None, minkowski_enabled=None, draft_angle_deg=None,
+              cone_segments=None, platen_fn=None):
+    """"Create Draft Angle Text" (v1:35-59) - character.chars stacked at
+    y=Baseline + n*Baselines_Shift_Motion (bottom to top: Figure_Char,
+    Lower_Char, Upper_Char for Oliver; +fun_char for Lumi), mirrored
+    together, unioned into ONE flat 2D shape, platen-cut (N real boolean
+    cylinders, BEFORE the Minkowski sum per CLAUDE.md's curvature-
+    before-Minkowski invariant), then Minkowski-summed with
+    _draft_cone()."""
+    _require_configured()
+    flatness_tolerance_mm = DEFAULT_FLATNESS_TOLERANCE_MM if flatness_tolerance_mm is None else flatness_tolerance_mm
+    minkowski_enabled = DEFAULT_MINKOWSKI_ENABLED if minkowski_enabled is None else minkowski_enabled
+
+    face = load_font_face(FONT_PATH)
+    scale = em_to_mm_scale(Font_Size, face.units_per_EM)
+    align_kwargs = _align_kwargs()
+    contours = []
+    for n, ch in enumerate(Character_Chars):
+        y = Baseline + n * Baselines_Shift_Motion
+        c_contours, advance_mm = get_glyph_contours_and_advance(ch, flatness_tolerance_mm, scale, font_path=FONT_PATH)
+        x_shift = alignment_x_offset(ch, advance_mm, **align_kwargs)
+        for c in c_contours:
+            contours.append(c + np.array([x_shift, y]))
+    contours = [c * np.array([-1.0, 1.0]) for c in contours]  # mirror([1,0,0]) - struck character
+
+    flat = classify_and_triangulate(contours)
+    prism = trimesh.creation.extrude_triangulation(flat.vertices[:, :2], flat.faces, Character_Block_Height_Mm)
+
+    scalloped = sp.to_manifold(prism)
+    for cutter in _platen_cylinders(platen_fn=platen_fn):
+        scalloped = scalloped - sp.to_manifold(cutter)
+
+    if not minkowski_enabled:
+        return sp.from_manifold(scalloped)
+
+    drafted = scalloped.minkowski_sum(_draft_cone(cone_segments=cone_segments, draft_angle_deg=draft_angle_deg))
+    return sp.from_manifold(drafted)
+
+
+# --------------------------------------------------------------- Cutters
+
+def _wing_taper_local(mirror_x):
+    """One wing-taper profile (v1:78/80-81), extruded along Z by
+    Body_Length+.002 then shifted by the shared translate([0,0,-.001])
+    both copies sit under (v1:76)."""
+    pts = [(Body_Width / 2.0, 0.0), (Body_Width / 2.0, -Engraving_Depth),
+           (Body_Width / 2.0 + 1.0, -Engraving_Depth), (Body_Width / 2.0 + 1.0, Body_Height),
+           (Body_Slot_Width / 2.0 + Wing_Thickness, Body_Height)]
+    if mirror_x:
+        pts = [(-x, y) for x, y in pts]
+    mesh = trimesh.creation.extrude_polygon(ShapelyPolygon(pts), Body_Length + 0.002)
+    mesh.apply_translation([0, 0, -0.001])
+    return mesh
+
+
+def _typebar_and_wing_taper_cuts():
+    """"Cut Typebar Slot"/"Cut Wing Tapers" (v1:68-82) - both real
+    children of one shared rotate([-90,0,0]) group (v1:68). See module
+    docstring for why this is one batched rotate over the union, not
+    three separate per-part transforms."""
+    slot = sp.box_centered([Body_Slot_Width, 10.0, Body_Length + 0.002],
+                            [0.0, Bottom_Thickness + 5.0, Body_Length / 2.0])
+    local = sp.union_all([slot, _wing_taper_local(False), _wing_taper_local(True)])
+    return sp.scad_transform(local, ("rotate", [-90, 0, 0]))
+
+
+def _wing_angle_cut(translate_xyz, rotate_xyz, angle_deg):
+    """"Cut Upper/Lower Wing Angle" (v1:85-95) - both real cuts use
+    Upper_Wing_Angle (see module docstring's Lower_Wing_Angle note)."""
+    h15 = Body_Height * 1.5
+    pts = [(-0.001, 0.0),
+           (h15 * np.sin(np.radians(angle_deg)), -h15 * np.cos(np.radians(angle_deg))),
+           (-Engraving_Depth, -h15), (-Engraving_Depth, Engraving_Depth), (0.0, Engraving_Depth)]
+    mesh = trimesh.creation.extrude_polygon(ShapelyPolygon(pts), 10.0)
+    return sp.scad_transform(mesh, ("translate", translate_xyz), ("rotate", rotate_xyz))
+
+
+def Subtractive():
+    _require_configured()
+    cuts = [_typebar_and_wing_taper_cuts(),
+            _wing_angle_cut([5.0, Body_Length, 0.0], [90, 0, -90], Upper_Wing_Angle),
+            _wing_angle_cut([-5.0, 0.0, 0.0], [90, 0, 90], Upper_Wing_Angle)]
+    return sp.union_all(cuts)
+
+
+# -------------------------------------------------------- Additive extras
+
+def Loop():
+    """LumiSlug.scad's trailing Loop block (v1:113-120) - see module
+    docstring for the shared scad_primitives.torus() recipe."""
+    _require_configured()
+    ring = sp.torus(Loop_Diameter / 2.0 - Loop_Thickness / 2.0, Loop_Thickness,
+                     sections=Loop_Fn, tube_sections=Loop_Tube_Fn)
+    return sp.scad_transform(ring, ("translate", [0, Body_Length, -Loop_Thickness / 2.0]),
+                              ("rotate", [0, Loop_Rotation, 0]))
+
+
+# ------------------------------------------------------------------ Element
+
+def Additive(flatness_tolerance_mm=None, separation_mm=None, render_core_groove=None,
+             cone_segments=None, platen_fn=None, minkowski_enabled=None, draft_angle_deg=None):
+    """separation_mm/render_core_groove are accepted-but-ignored - this
+    machine has neither concept, same pattern lib/wing_slug.py's own
+    Additive() and the Selectric family establish."""
+    _require_configured()
+    return sp.union_all([
+        BodyBox(),
+        DraftText(flatness_tolerance_mm=flatness_tolerance_mm, minkowski_enabled=minkowski_enabled,
+                  draft_angle_deg=draft_angle_deg, cone_segments=cone_segments, platen_fn=platen_fn),
+    ])
+
+
+def FullElement(flatness_tolerance_mm=None, separation_mm=None, render_core_groove=None,
+                cone_segments=None, platen_fn=None, minkowski_enabled=None, draft_angle_deg=None):
+    """v1's `union(){ difference(){additive; cuts;}; loop; }` (see module
+    docstring - Loop, when enabled, sits OUTSIDE the cut difference, not
+    inside it)."""
+    _require_configured()
+    additive = Additive(flatness_tolerance_mm=flatness_tolerance_mm, separation_mm=separation_mm,
+                         render_core_groove=render_core_groove, cone_segments=cone_segments,
+                         platen_fn=platen_fn, minkowski_enabled=minkowski_enabled,
+                         draft_angle_deg=draft_angle_deg)
+    result = additive.difference(Subtractive(), engine="manifold")
+    if Element_Loop_Enabled:
+        result = sp.union_all([result, Loop()])
+    result, _, _, _ = sp.check_and_repair(result, label="FullElement")
+    build_log.mesh_report(result, "FullElement")
+    return result, []
+
+
+def ResinSupport():
+    """No resin-support geometry exists anywhere in either real v1
+    source for this family (see module docstring) - real function
+    returning None, same convention lib/helios.py's own ResinSupport()
+    establishes for a machine with none modeled."""
+    return None
+
+
+def ResinPrint(flatness_tolerance_mm=None, separation_mm=None, render_core_groove=None,
+               cone_segments=None, platen_fn=None, minkowski_enabled=None, draft_angle_deg=None):
+    """Real no-op passthrough to FullElement() - see module docstring
+    and lib/helios.py's own ResinPrint() for the established precedent."""
+    _require_configured()
+    return FullElement(flatness_tolerance_mm=flatness_tolerance_mm, separation_mm=separation_mm,
+                        render_core_groove=render_core_groove, cone_segments=cone_segments,
+                        platen_fn=platen_fn, minkowski_enabled=minkowski_enabled,
+                        draft_angle_deg=draft_angle_deg)

--- a/v4/lib/gauge_slug.py
+++ b/v4/lib/gauge_slug.py
@@ -1,0 +1,145 @@
+"""
+v4 Gauge Slug - ports v1/Type Slugs/GaugeTypeSlugSlug.scad. The one
+REAL, functional member of this family (unlike TypeSlug/VogueSlug/
+OliverSlug/LumiSlug, which are novelty/reference replicas): no struck
+character, no logo - just the wing body with a two-row tick-hole ladder
+(gauge.fine_pitch_mm/gauge.major_pitch_mm) drilled down one side,
+meant to be installed on the real machine and used to measure/calibrate
+typebar swing and alignment-cut position directly, the same way
+Blickensderfer/Postal's own Shaft Gauge Test print is a real measuring
+tool rather than a preview of the final part. Shares lib/wing_slug.py's
+engine with lib/type_slug.py/lib/vogue_slug.py - see that module's
+docstring for the shared geometry pipeline (Ticks(), used only when
+gauge.enabled, and the v1-is-ground-truth callout).
+
+All real numbers live in config/gauge_slug.yaml - call configure(path)
+once before using anything else in this module (see generate.py).
+"""
+
+import yaml
+
+import wing_slug
+from wing_slug import FullElement, ResinPrint, Additive  # re-exported for callers
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    g["Font_Size"] = font["size_mm"]
+
+    align = cfg["alignment"]
+    g["Align_Mode"] = align["mode"]
+    g["Align_Center_Offset_Mm"] = align["center_offset_mm"]
+    g["Align_Left_Offset_Mm"] = align["left_offset_mm"]
+    g["Align_Modified_Left_Chars"] = align["modified_left_chars"]
+    g["Align_Modified_Left_Offset_Mm"] = align["modified_left_offset_mm"]
+    g["Align_Modified_Right_Chars"] = align["modified_right_chars"]
+    g["Align_Modified_Right_Offset_Mm"] = align["modified_right_offset_mm"]
+
+    char = cfg["character"]
+    g["Character_Enabled"] = char["char_enabled"]
+    g["Lower_Char"] = char["lower_char"]
+    g["Upper_Char"] = char["upper_char"]
+
+    logo = cfg["logo"]
+    g["Logo_Enabled"] = logo["logo_enabled"]
+    g["Logo_Svg_File"] = logo["svg_file"]
+    g["Logo_Scale_Mm_Per_Unit"] = logo["scale_mm_per_unit"]
+    g["Logo_Depth_Mm"] = logo["logo_depth_mm"]
+    g["Logo_Location"] = logo["location_frac"]
+    g["Logo_Vogue_Enabled"] = logo["vogue_enabled"]
+    g["Vogue_Arrow_Svg_File"] = logo["vogue_arrow_svg_file"]
+    g["Vogue_V_Svg_File"] = logo["vogue_v_svg_file"]
+
+    lbl = cfg["label"]
+    g["Copyright_Text"] = lbl["text"]
+    g["Copyright_Font"] = lbl["font_path"]
+    g["Copyright_Depth"] = lbl["label_depth_mm"]
+
+    e = cfg["element"]
+    g["Body_Width"] = e["body_width_mm"]
+    g["Body_Length"] = e["body_length_mm"]
+    g["Body_Height"] = e["body_height_mm"]
+    g["Face_Thickness"] = e["face_thickness_mm"]
+    g["Face_Radius"] = e["face_radius_mm"]
+    g["Wing_Radius"] = e["wing_radius_mm"]
+    g["Platen_Shift_Motion"] = e["platen_shift_motion_mm"]
+    g["Baselines_Shift_Motion"] = e["baselines_shift_motion_mm"]
+    g["Body_Slot_Width"] = e["body_slot_width_mm"]
+    g["Wing_Thickness"] = e["wing_thickness_mm"]
+    g["Aligning_Cut"] = e["aligning_cut_mm"]
+    g["Baseline"] = e["baseline_mm"]
+    g["Platen_Diameter"] = e["platen_diameter_mm"]
+    g["Bottom_Thickness"] = e["bottom_thickness_mm"]
+    g["Upper_Wing_Angle"] = e["upper_wing_angle_deg"]
+    g["Lower_Wing_Angle"] = e["lower_wing_angle_deg"]
+    g["Element_Loop_Enabled"] = e["loop_enabled"]
+    g["Loop_Thickness"] = e["loop_thickness_mm"]
+    g["Loop_Diameter"] = e["loop_diameter_mm"]
+    g["Loop_Rotation"] = e["loop_rotation_deg"]
+    g["Element_Post_Enabled"] = e["post_enabled"]
+    g["Post_ID"] = e["post_id_mm"]
+    g["Post_OD"] = e["post_od_mm"]
+    g["Element_Side_Hole_Enabled"] = e["side_hole_enabled"]
+    g["Side_Hole_ID"] = e["side_hole_id_mm"]
+    g["Side_Hole_Height"] = e["side_hole_height_frac"]
+
+    b = cfg["build"]
+    g["DEFAULT_FLATNESS_TOLERANCE_MM"] = b["flatness_tolerance_mm"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Draft_Angle"] = b["draft_angle_deg"]
+    g["Engraving_Depth"] = b["engraving_depth_mm"]
+    g["Minkowski_Multiplier"] = b["minkowski_multiplier"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Corner_Fn"] = q["corner_fn"]
+    g["Wing_Fn"] = q["wing_fn"]
+    g["Platen_Fn"] = q["platen_fn"]
+    g["Minkowski_Fn"] = q["minkowski_fn"]
+    g["Loop_Fn"] = q["loop_fn"]
+    g["Loop_Tube_Fn"] = q["loop_tube_fn"]
+    g["Post_Fn"] = q["post_fn"]
+    g["Side_Hole_Fn"] = q["side_hole_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+    g["Raft_Thickness"] = r["raft_thickness_mm"]
+    g["Wire_Thickness"] = r["wire_thickness_mm"]
+    g["Support_Height"] = r["support_height_mm"]
+    g["Support_Pitch"] = r["support_pitch_mm"]
+
+    gauge = cfg["gauge"]
+    g["Gauge_Enabled"] = gauge["gauge_enabled"]
+    g["Gauge_Fine_Pitch_Mm"] = gauge["fine_pitch_mm"]
+    g["Gauge_Major_Pitch_Mm"] = gauge["major_pitch_mm"]
+    g["Gauge_Hole_D_Mm"] = gauge["hole_d_mm"]
+    g["Gauge_Fine_Z_Mm"] = gauge["fine_z_mm"]
+    g["Gauge_Major_Z_Mm"] = gauge["major_z_mm"]
+    g["Gauge_Hole_Fn"] = gauge["hole_fn"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    tt = cfg.get("type_test", {})
+    g["Test_CPI"] = tt.get("cpi", 10.0)
+    g["Test_String_Custom"] = tt.get("text", "")
+
+    _configured = True
+    wing_slug._receive_config(g, "gauge_slug")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call gauge_slug.configure(config_path) before using this module")

--- a/v4/lib/lumi_slug.py
+++ b/v4/lib/lumi_slug.py
@@ -1,0 +1,94 @@
+"""
+v4 Lumi Slug - ports v1/Type Slugs/LumiSlug.scad, a pure novelty item (a
+4-character loop pendant - "novelty" per the user's own framing, same as
+lib/oliver_slug.py). Shares lib/box_slug.py's engine with lib/
+oliver_slug.py - see that module's docstring for the shared geometry
+pipeline and the v1-is-ground-truth callout.
+
+All real numbers live in config/lumi_slug.yaml - call configure(path)
+once before using anything else in this module (see generate.py).
+"""
+
+import yaml
+
+import box_slug
+from box_slug import FullElement, ResinPrint, Additive  # re-exported for callers
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    g["Font_Size"] = font["size_mm"]
+
+    align = cfg["alignment"]
+    g["Align_Mode"] = align["mode"]
+    g["Align_Center_Offset_Mm"] = align["center_offset_mm"]
+    g["Align_Left_Offset_Mm"] = align["left_offset_mm"]
+    g["Align_Modified_Left_Chars"] = align["modified_left_chars"]
+    g["Align_Modified_Left_Offset_Mm"] = align["modified_left_offset_mm"]
+    g["Align_Modified_Right_Chars"] = align["modified_right_chars"]
+    g["Align_Modified_Right_Offset_Mm"] = align["modified_right_offset_mm"]
+
+    char = cfg["character"]
+    g["Character_Chars"] = char["chars"]
+    g["Baseline"] = char["baseline_mm"]
+    g["Baselines_Shift_Motion"] = char["baselines_shift_motion_mm"]
+
+    e = cfg["element"]
+    g["Body_Width"] = e["body_width_mm"]
+    g["Body_Length"] = e["body_length_mm"]
+    g["Body_Height"] = e["body_height_mm"]
+    g["Platen_Shift_Motion"] = e["platen_shift_motion_mm"]
+    g["Body_Slot_Width"] = e["body_slot_width_mm"]
+    g["Wing_Thickness"] = e["wing_thickness_mm"]
+    g["Aligning_Cut"] = e["aligning_cut_mm"]
+    g["Platen_Diameter"] = e["platen_diameter_mm"]
+    g["Bottom_Thickness"] = e["bottom_thickness_mm"]
+    g["Upper_Wing_Angle"] = e["upper_wing_angle_deg"]
+    g["Element_Loop_Enabled"] = e["loop_enabled"]
+    g["Loop_Thickness"] = e["loop_thickness_mm"]
+    g["Loop_Diameter"] = e["loop_diameter_mm"]
+    g["Loop_Rotation"] = e["loop_rotation_deg"]
+
+    b = cfg["build"]
+    g["DEFAULT_FLATNESS_TOLERANCE_MM"] = b["flatness_tolerance_mm"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Draft_Angle"] = b["draft_angle_deg"]
+    g["Engraving_Depth"] = b["engraving_depth_mm"]
+    g["Minkowski_Multiplier"] = b["minkowski_multiplier"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Minkowski_Fn"] = q["minkowski_fn"]
+    g["Platen_Fn"] = q["platen_fn"]
+    g["Loop_Fn"] = q["loop_fn"]
+    g["Loop_Tube_Fn"] = q["loop_tube_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    tt = cfg.get("type_test", {})
+    g["Test_CPI"] = tt.get("cpi", 10.0)
+    g["Test_String_Custom"] = tt.get("text", "")
+
+    _configured = True
+    box_slug._receive_config(g, "lumi_slug")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call lumi_slug.configure(config_path) before using this module")

--- a/v4/lib/oliver_slug.py
+++ b/v4/lib/oliver_slug.py
@@ -1,0 +1,94 @@
+"""
+v4 Oliver Slug - ports v1/Type Slugs/OliverSlug.scad, a replica modeled
+after a real Oliver typewriter type slug (novelty/reference, not a
+functional part - per the user's own framing). Shares lib/box_slug.py's
+engine with lib/lumi_slug.py - see that module's docstring for the
+shared geometry pipeline and the v1-is-ground-truth callout.
+
+All real numbers live in config/oliver_slug.yaml - call configure(path)
+once before using anything else in this module (see generate.py).
+"""
+
+import yaml
+
+import box_slug
+from box_slug import FullElement, ResinPrint, Additive  # re-exported for callers
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    g["Font_Size"] = font["size_mm"]
+
+    align = cfg["alignment"]
+    g["Align_Mode"] = align["mode"]
+    g["Align_Center_Offset_Mm"] = align["center_offset_mm"]
+    g["Align_Left_Offset_Mm"] = align["left_offset_mm"]
+    g["Align_Modified_Left_Chars"] = align["modified_left_chars"]
+    g["Align_Modified_Left_Offset_Mm"] = align["modified_left_offset_mm"]
+    g["Align_Modified_Right_Chars"] = align["modified_right_chars"]
+    g["Align_Modified_Right_Offset_Mm"] = align["modified_right_offset_mm"]
+
+    char = cfg["character"]
+    g["Character_Chars"] = char["chars"]
+    g["Baseline"] = char["baseline_mm"]
+    g["Baselines_Shift_Motion"] = char["baselines_shift_motion_mm"]
+
+    e = cfg["element"]
+    g["Body_Width"] = e["body_width_mm"]
+    g["Body_Length"] = e["body_length_mm"]
+    g["Body_Height"] = e["body_height_mm"]
+    g["Platen_Shift_Motion"] = e["platen_shift_motion_mm"]
+    g["Body_Slot_Width"] = e["body_slot_width_mm"]
+    g["Wing_Thickness"] = e["wing_thickness_mm"]
+    g["Aligning_Cut"] = e["aligning_cut_mm"]
+    g["Platen_Diameter"] = e["platen_diameter_mm"]
+    g["Bottom_Thickness"] = e["bottom_thickness_mm"]
+    g["Upper_Wing_Angle"] = e["upper_wing_angle_deg"]
+    g["Element_Loop_Enabled"] = e["loop_enabled"]
+    g["Loop_Thickness"] = e["loop_thickness_mm"]
+    g["Loop_Diameter"] = e["loop_diameter_mm"]
+    g["Loop_Rotation"] = e["loop_rotation_deg"]
+
+    b = cfg["build"]
+    g["DEFAULT_FLATNESS_TOLERANCE_MM"] = b["flatness_tolerance_mm"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Draft_Angle"] = b["draft_angle_deg"]
+    g["Engraving_Depth"] = b["engraving_depth_mm"]
+    g["Minkowski_Multiplier"] = b["minkowski_multiplier"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Minkowski_Fn"] = q["minkowski_fn"]
+    g["Platen_Fn"] = q["platen_fn"]
+    g["Loop_Fn"] = q["loop_fn"]
+    g["Loop_Tube_Fn"] = q["loop_tube_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    tt = cfg.get("type_test", {})
+    g["Test_CPI"] = tt.get("cpi", 10.0)
+    g["Test_String_Custom"] = tt.get("text", "")
+
+    _configured = True
+    box_slug._receive_config(g, "oliver_slug")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call oliver_slug.configure(config_path) before using this module")

--- a/v4/lib/scad_primitives.py
+++ b/v4/lib/scad_primitives.py
@@ -175,6 +175,37 @@ def frustum_z(d1, d2, height, sections=128, base_z=0.0):
     return m
 
 
+def torus(center_radius, tube_diameter, sections=128, tube_sections=32):
+    """rotate_extrude(){translate([center_radius,0]) circle(d=tube_diameter);}
+    equivalent - a torus (ring) profile swept around Z, offset outward by
+    center_radius. First shared call sites: lib/wing_slug.py's and lib/
+    box_slug.py's Loop() - the same real torus recipe, byte-identical
+    between v1/Type Slugs/TypeSlug.scad's and LumiSlug.scad's own Loop
+    blocks, extracted here per CLAUDE.md's "when two machines share a
+    derivation, extract it" convention rather than hand-copied twice.
+
+    sections drives the sweep-around-the-ring resolution (matches v1's
+    own rotate_extrude($fn=360)); tube_sections drives the tube's own
+    small-circle cross-section point count SEPARATELY (v1 also uses
+    $fn=360 there - circle(d=tube_diameter, $fn=360) - but reusing one
+    $fn=360 for BOTH axes of a torus this small is a real, measured
+    100x-facet-count blow-up (360*360=129600 vertices for a single
+    keyring-style loop torus, confirmed on Lumi Slug's real config
+    values, vs. the same shape at tube_sections=32: ~11500 - both
+    watertight/valid, only the wasted-density one differs) with no
+    visible quality gain on a sub-1mm tube radius - not ported as a
+    literal 1:1 facet count for that reason, per CLAUDE.md's "if there's
+    no real reason to invent a special-cased number, don't" (here read
+    as: an accidentally-uniform $fn in the real v1 source is not itself
+    a real reason to keep two geometrically independent axes coupled).
+    Exposed as its own config knob (quality.loop_tube_fn) rather than a
+    hardcoded default, same as every other facet count in this
+    pipeline."""
+    theta = np.linspace(0, 2 * np.pi, tube_sections, endpoint=False)
+    profile = [(center_radius + tube_diameter / 2.0 * np.cos(t), tube_diameter / 2.0 * np.sin(t)) for t in theta]
+    return revolve_polygon(profile, sections=sections)
+
+
 def box_centered(extents, center):
     """cube(size, center=true) equivalent placed at an arbitrary center."""
     b = trimesh.creation.box(extents=extents)

--- a/v4/lib/svg_import.py
+++ b/v4/lib/svg_import.py
@@ -1,0 +1,328 @@
+"""
+Minimal SVG <path> importer, for the Vogue foundry mark and the generic
+AR1 logo (lib/wing_slug.py's Logo feature, ported from v1/Type Slugs/
+TypeSlug.scad's/VogueSlug.scad's `import(SVG_File, center=true)` +
+minkowski() draft). v1 relied on OpenSCAD's own built-in SVG importer;
+v4 has none (see requirements.txt - no svg/xml geometry library), so
+this is a real, from-scratch path-data parser, not a shortcut - per
+CLAUDE.md's geometry invariants, the logo still has to go through the
+same real Minkowski/boolean pipeline as every struck character.
+
+Scope: only <path d="..."> elements are read (every hand-drawn SVG this
+repo actually uses - AR1.svg, vogue-foundry-*.svg - is a flat list of
+<path>s with no <rect>/<circle>/<use>/<g transform=...>/gradient/clip
+content - confirmed by inspection), across the standard SVG path command
+set (M/L/H/V/C/S/Q/T/A, upper absolute + lower relative, Z close). Curve
+flattening reuses glyph_poc's adaptive de Casteljau subdivision
+(flatten_cubic/flatten_quadratic) - same flatness_tolerance_mm knob,
+same technique, not a separate/second curve-flattening scheme.
+
+Coordinate convention: SVG authoring space is Y-DOWN; this module
+returns Y-UP mm contours (negates Y after scaling) so a parsed logo
+reads right-side-up next to the rest of v4's Y-up geometry - a
+DELIBERATE v4-only convention, not a port of OpenSCAD's own import(svg)
+pixel/DPI scaling (which OpenSCAD derives from a 96px/inch assumption
+baked into its importer - reproducing that exactly would need empirical
+calibration against openscad-nightly the way glyph_poc.
+OPENSCAD_TEXT_DPI_FACTOR was for text(), and this is a decorative logo
+mark, not a physically-toleranced struck character, so it isn't worth
+that same calibration effort). Callers pick their own mm-per-SVG-unit
+scale explicitly (config's logo.svg_scale_mm_per_unit / logo.
+svg_v1_scale_mm_per_unit) rather than inheriting v1's SVG_Scale=1/40
+constants, which were tuned against OpenSCAD's own (different) import
+convention and would not mean the same thing here.
+"""
+
+import re
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+from glyph_poc import flatten_cubic, flatten_quadratic
+
+
+_TOKEN_RE = re.compile(r"[MmLlHhVvCcSsQqTtAaZz]|-?\d*\.?\d+(?:[eE][-+]?\d+)?")
+
+
+def _tokenize(d):
+    return _TOKEN_RE.findall(d)
+
+
+def _flatten_arc(p0, rx, ry, phi_deg, large_arc, sweep, p1, tol):
+    """Elliptical arc (SVG path A/a) -> flattened points. Endpoint-to-
+    center parameterization (SVG 1.1 spec appendix F.6), then split into
+    cubic Bezier segments <=90deg each via the standard unit-circle-arc
+    control-point formula (k = 4/3*tan(delta/4)), transformed by
+    (rx,ry,phi) and flattened at the real flatness_tolerance_mm via
+    glyph_poc.flatten_cubic. Degenerate rx/ry/coincident-endpoint cases
+    fall back to a straight line, matching the spec's own "treat as
+    line" rule."""
+    x1, y1 = p0
+    x2, y2 = p1
+    if (x1, y1) == (x2, y2):
+        return []
+    rx_, ry_ = abs(rx), abs(ry)
+    if rx_ < 1e-9 or ry_ < 1e-9:
+        return [np.array([x2, y2])]
+
+    phi = np.radians(phi_deg)
+    cphi, sphi = np.cos(phi), np.sin(phi)
+    dx2, dy2 = (x1 - x2) / 2.0, (y1 - y2) / 2.0
+    x1p = cphi * dx2 + sphi * dy2
+    y1p = -sphi * dx2 + cphi * dy2
+
+    lam = (x1p ** 2) / (rx_ ** 2) + (y1p ** 2) / (ry_ ** 2)
+    if lam > 1:
+        s = np.sqrt(lam)
+        rx_, ry_ = rx_ * s, ry_ * s
+
+    sign = -1.0 if large_arc == sweep else 1.0
+    num = rx_ ** 2 * ry_ ** 2 - rx_ ** 2 * y1p ** 2 - ry_ ** 2 * x1p ** 2
+    denom = rx_ ** 2 * y1p ** 2 + ry_ ** 2 * x1p ** 2
+    co = sign * np.sqrt(max(0.0, num / denom)) if denom > 1e-12 else 0.0
+    cxp = co * rx_ * y1p / ry_
+    cyp = -co * ry_ * x1p / rx_
+
+    cx = cphi * cxp - sphi * cyp + (x1 + x2) / 2.0
+    cy = sphi * cxp + cphi * cyp + (y1 + y2) / 2.0
+
+    def _angle(ux, uy, vx, vy):
+        dot = ux * vx + uy * vy
+        length = np.hypot(ux, uy) * np.hypot(vx, vy)
+        ang = np.arccos(np.clip(dot / length, -1.0, 1.0))
+        return ang if (ux * vy - uy * vx) >= 0 else -ang
+
+    ux, uy = (x1p - cxp) / rx_, (y1p - cyp) / ry_
+    vx, vy = (-x1p - cxp) / rx_, (-y1p - cyp) / ry_
+    theta1 = _angle(1.0, 0.0, ux, uy)
+    dtheta = _angle(ux, uy, vx, vy)
+    if sweep == 0 and dtheta > 0:
+        dtheta -= 2 * np.pi
+    elif sweep == 1 and dtheta < 0:
+        dtheta += 2 * np.pi
+
+    n_segments = max(1, int(np.ceil(abs(dtheta) / (np.pi / 2.0))))
+    delta = dtheta / n_segments
+    k = 4.0 / 3.0 * np.tan(delta / 4.0)
+
+    def _point(theta):
+        ex = rx_ * np.cos(theta)
+        ey = ry_ * np.sin(theta)
+        return np.array([cphi * ex - sphi * ey + cx, sphi * ex + cphi * ey + cy])
+
+    def _deriv(theta):
+        ex = -rx_ * np.sin(theta)
+        ey = ry_ * np.cos(theta)
+        return np.array([cphi * ex - sphi * ey, sphi * ex + cphi * ey])
+
+    out = []
+    cur = np.array([x1, y1])
+    for i in range(n_segments):
+        t0 = theta1 + i * delta
+        t1 = t0 + delta
+        p_end = _point(t1)
+        c1 = cur + k * _deriv(t0)
+        c2 = p_end - k * _deriv(t1)
+        out.extend(flatten_cubic(cur, c1, c2, p_end, tol))
+        cur = p_end
+    return out
+
+
+def _parse_path_d(d, flatness_tolerance_mm):
+    """Walks one <path>'s d= command string into a list of closed
+    subpaths (each a list of (x,y) np.arrays, absolute user-space
+    units). Multiple M-started subpaths in one d= string are common
+    (a glyph-like mark with a counter/hole) - each becomes its own
+    closed contour, left for the caller's classify_and_triangulate()
+    nesting-depth fill logic to sort hole vs. island, same as a font's
+    multi-contour glyph."""
+    tokens = _tokenize(d)
+    i = 0
+    n = len(tokens)
+
+    def read_floats(count):
+        nonlocal i
+        vals = [float(tokens[i + k]) for k in range(count)]
+        i += count
+        return vals
+
+    subpaths = []
+    cur = np.array([0.0, 0.0])
+    subpath_start = cur
+    current_pts = None
+    cmd = None
+    prev_cubic_ctrl = None
+    prev_quad_ctrl = None
+
+    while i < n:
+        tok = tokens[i]
+        if tok.isalpha():
+            cmd = tok
+            i += 1
+        # else: implicit repeat of the previous command (SVG shorthand)
+        is_rel = cmd.islower()
+        c = cmd.upper()
+
+        if c == "M":
+            x, y = read_floats(2)
+            if is_rel and current_pts is not None:
+                x, y = cur[0] + x, cur[1] + y
+            cur = np.array([x, y])
+            if current_pts:
+                subpaths.append(current_pts)
+            current_pts = [cur]
+            subpath_start = cur
+            cmd = "l" if is_rel else "L"  # subsequent bare coord pairs are lineto
+        elif c == "L":
+            x, y = read_floats(2)
+            if is_rel:
+                x, y = cur[0] + x, cur[1] + y
+            cur = np.array([x, y])
+            current_pts.append(cur)
+        elif c == "H":
+            (x,) = read_floats(1)
+            if is_rel:
+                x = cur[0] + x
+            cur = np.array([x, cur[1]])
+            current_pts.append(cur)
+        elif c == "V":
+            (y,) = read_floats(1)
+            if is_rel:
+                y = cur[1] + y
+            cur = np.array([cur[0], y])
+            current_pts.append(cur)
+        elif c == "C":
+            x1, y1, x2, y2, x, y = read_floats(6)
+            if is_rel:
+                x1, y1 = cur[0] + x1, cur[1] + y1
+                x2, y2 = cur[0] + x2, cur[1] + y2
+                x, y = cur[0] + x, cur[1] + y
+            p1, p2, p3 = np.array([x1, y1]), np.array([x2, y2]), np.array([x, y])
+            current_pts.extend(flatten_cubic(cur, p1, p2, p3, flatness_tolerance_mm))
+            prev_cubic_ctrl = p2
+            cur = p3
+        elif c == "S":
+            x2, y2, x, y = read_floats(4)
+            if is_rel:
+                x2, y2 = cur[0] + x2, cur[1] + y2
+                x, y = cur[0] + x, cur[1] + y
+            p1 = 2 * cur - prev_cubic_ctrl if prev_cubic_ctrl is not None else cur
+            p2, p3 = np.array([x2, y2]), np.array([x, y])
+            current_pts.extend(flatten_cubic(cur, p1, p2, p3, flatness_tolerance_mm))
+            prev_cubic_ctrl = p2
+            cur = p3
+        elif c == "Q":
+            x1, y1, x, y = read_floats(4)
+            if is_rel:
+                x1, y1 = cur[0] + x1, cur[1] + y1
+                x, y = cur[0] + x, cur[1] + y
+            p1, p2 = np.array([x1, y1]), np.array([x, y])
+            current_pts.extend(flatten_quadratic(cur, p1, p2, flatness_tolerance_mm))
+            prev_quad_ctrl = p1
+            cur = p2
+        elif c == "T":
+            x, y = read_floats(2)
+            if is_rel:
+                x, y = cur[0] + x, cur[1] + y
+            p1 = 2 * cur - prev_quad_ctrl if prev_quad_ctrl is not None else cur
+            p2 = np.array([x, y])
+            current_pts.extend(flatten_quadratic(cur, p1, p2, flatness_tolerance_mm))
+            prev_quad_ctrl = p1
+            cur = p2
+        elif c == "A":
+            rx, ry, xrot, large_arc, sweep, x, y = read_floats(7)
+            if is_rel:
+                x, y = cur[0] + x, cur[1] + y
+            end = np.array([x, y])
+            current_pts.extend(_flatten_arc(cur, rx, ry, xrot, int(large_arc), int(sweep), end,
+                                             flatness_tolerance_mm))
+            cur = end
+        elif c == "Z":
+            cur = subpath_start
+            if current_pts and not np.allclose(current_pts[-1], subpath_start):
+                current_pts.append(subpath_start)
+        else:
+            raise ValueError(f"unsupported SVG path command {c!r}")
+
+        if c not in ("C", "S", "Q", "T"):
+            prev_cubic_ctrl = None
+            prev_quad_ctrl = None
+
+    if current_pts:
+        subpaths.append(current_pts)
+
+    out = []
+    for pts in subpaths:
+        arr = np.array([p for p in pts])
+        if len(arr) >= 2 and np.allclose(arr[0], arr[-1]):
+            arr = arr[:-1]
+        if len(arr) >= 3:
+            out.append(arr)
+    return out
+
+
+def parse_svg_contours_mm(svg_path, flatness_tolerance_mm, scale_mm_per_unit, center=True):
+    """Reads every <path> in svg_path (namespace-agnostic - SVG's default
+    xmlns means ElementTree tags come back as "{http://www.w3.org/2000/
+    svg}path", matched here via a local-name check rather than a
+    hardcoded namespace string), flattens each into closed 2D contours,
+    scales to mm, and flips Y (SVG authoring convention is Y-down - see
+    module docstring). Returns a flat list of (x,y) np.ndarrays ready
+    for glyph_poc.classify_and_triangulate() - multiple <path> elements
+    and multiple M-subpaths within one path are both just more contours
+    in that same flat list, correctly resolved into solid/hole material
+    by classify_and_triangulate's own nesting-depth logic (no separate
+    per-path handling needed).
+
+    center=True (the default, matching v1's only usage - `import(file,
+    center=true)` at every real call site) shifts every contour so the
+    WHOLE file's combined bounding box is centered on the origin.
+    Centering commutes with the uniform scale/Y-flip already applied
+    above (no rotation/skew involved), so doing it here in output mm
+    space rather than in raw SVG-unit space beforehand is equivalent to
+    OpenSCAD's own pre-transform centering, just simpler to express."""
+    tree = ET.parse(svg_path)
+    root = tree.getroot()
+    contours = []
+    for elem in root.iter():
+        tag = elem.tag.split("}")[-1]
+        if tag != "path":
+            continue
+        d = elem.get("d")
+        if not d:
+            continue
+        for contour in _parse_path_d(d, flatness_tolerance_mm / scale_mm_per_unit):
+            pts = contour * scale_mm_per_unit
+            pts[:, 1] *= -1.0
+            contours.append(pts)
+    if center and contours:
+        all_pts = np.concatenate(contours, axis=0)
+        bbox_center = (all_pts.min(axis=0) + all_pts.max(axis=0)) / 2.0
+        contours = [c - bbox_center for c in contours]
+    return contours
+
+
+def build_svg_logo_mesh_2d(svg_paths, flatness_tolerance_mm, scale_mm_per_unit, offsets=None):
+    """Parses one or more SVG files (e.g. VogueSlug's separate arrow +
+    V marks, each with its own placement offset - v1/Type Slugs/
+    VogueSlug.scad:113-121) into ONE combined flat (z=0) triangulated
+    trimesh.Trimesh, via glyph_poc.classify_and_triangulate - the same
+    hole/island nesting-depth fill logic used for real font glyphs,
+    reused here since a multi-path logo mark has exactly the same
+    "which contour is solid vs. a hole" problem. offsets, if given, is a
+    list of (dx, dy) mm shifts applied per svg_paths entry BEFORE fill
+    classification (so two marks placed side by side don't need their
+    own separate triangulation/union - matching v1's own single
+    minkowski(){ linear_extrude { import(); import(); } } construction,
+    which drafts the two pieces as one combined swept solid, not two
+    separately-drafted ones unioned after)."""
+    from glyph_poc import classify_and_triangulate
+
+    if offsets is None:
+        offsets = [(0.0, 0.0)] * len(svg_paths)
+    all_contours = []
+    for svg_path, (dx, dy) in zip(svg_paths, offsets):
+        contours = parse_svg_contours_mm(svg_path, flatness_tolerance_mm, scale_mm_per_unit)
+        for c in contours:
+            all_contours.append(c + np.array([dx, dy]))
+    return classify_and_triangulate(all_contours)

--- a/v4/lib/type_slug.py
+++ b/v4/lib/type_slug.py
@@ -1,0 +1,139 @@
+"""
+v4 generic Type Slug - ports v1/Type Slugs/TypeSlug.scad, the base engine
+of the "wing body" novelty type-slug family (see lib/wing_slug.py's
+module docstring for the shared geometry pipeline and the v1-is-ground-
+truth callout). Struck lower/upper character pair plus an optional
+generic engraved SVG logo (AR1.svg by default) - "novelty, not real
+stuff" per the user's own framing, unlike lib/gauge_slug.py.
+
+All real numbers live in config/type_slug.yaml - call configure(path)
+once before using anything else in this module (see generate.py).
+"""
+
+import yaml
+
+import wing_slug
+from wing_slug import FullElement, ResinPrint, Additive  # re-exported for callers
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    g["Font_Size"] = font["size_mm"]
+
+    align = cfg["alignment"]
+    g["Align_Mode"] = align["mode"]
+    g["Align_Center_Offset_Mm"] = align["center_offset_mm"]
+    g["Align_Left_Offset_Mm"] = align["left_offset_mm"]
+    g["Align_Modified_Left_Chars"] = align["modified_left_chars"]
+    g["Align_Modified_Left_Offset_Mm"] = align["modified_left_offset_mm"]
+    g["Align_Modified_Right_Chars"] = align["modified_right_chars"]
+    g["Align_Modified_Right_Offset_Mm"] = align["modified_right_offset_mm"]
+
+    char = cfg["character"]
+    g["Character_Enabled"] = char["char_enabled"]
+    g["Lower_Char"] = char["lower_char"]
+    g["Upper_Char"] = char["upper_char"]
+
+    logo = cfg["logo"]
+    g["Logo_Enabled"] = logo["logo_enabled"]
+    g["Logo_Svg_File"] = logo["svg_file"]
+    g["Logo_Scale_Mm_Per_Unit"] = logo["scale_mm_per_unit"]
+    g["Logo_Depth_Mm"] = logo["logo_depth_mm"]
+    g["Logo_Location"] = logo["location_frac"]
+    g["Logo_Vogue_Enabled"] = logo["vogue_enabled"]
+    g["Vogue_Arrow_Svg_File"] = logo["vogue_arrow_svg_file"]
+    g["Vogue_V_Svg_File"] = logo["vogue_v_svg_file"]
+
+    lbl = cfg["label"]
+    g["Copyright_Text"] = lbl["text"]
+    g["Copyright_Font"] = lbl["font_path"]
+    g["Copyright_Depth"] = lbl["label_depth_mm"]
+
+    e = cfg["element"]
+    g["Body_Width"] = e["body_width_mm"]
+    g["Body_Length"] = e["body_length_mm"]
+    g["Body_Height"] = e["body_height_mm"]
+    g["Face_Thickness"] = e["face_thickness_mm"]
+    g["Face_Radius"] = e["face_radius_mm"]
+    g["Wing_Radius"] = e["wing_radius_mm"]
+    g["Platen_Shift_Motion"] = e["platen_shift_motion_mm"]
+    g["Baselines_Shift_Motion"] = e["baselines_shift_motion_mm"]
+    g["Body_Slot_Width"] = e["body_slot_width_mm"]
+    g["Wing_Thickness"] = e["wing_thickness_mm"]
+    g["Aligning_Cut"] = e["aligning_cut_mm"]
+    g["Baseline"] = e["baseline_mm"]
+    g["Platen_Diameter"] = e["platen_diameter_mm"]
+    g["Bottom_Thickness"] = e["bottom_thickness_mm"]
+    g["Upper_Wing_Angle"] = e["upper_wing_angle_deg"]
+    g["Lower_Wing_Angle"] = e["lower_wing_angle_deg"]
+    g["Element_Loop_Enabled"] = e["loop_enabled"]
+    g["Loop_Thickness"] = e["loop_thickness_mm"]
+    g["Loop_Diameter"] = e["loop_diameter_mm"]
+    g["Loop_Rotation"] = e["loop_rotation_deg"]
+    g["Element_Post_Enabled"] = e["post_enabled"]
+    g["Post_ID"] = e["post_id_mm"]
+    g["Post_OD"] = e["post_od_mm"]
+    g["Element_Side_Hole_Enabled"] = e["side_hole_enabled"]
+    g["Side_Hole_ID"] = e["side_hole_id_mm"]
+    g["Side_Hole_Height"] = e["side_hole_height_frac"]
+
+    b = cfg["build"]
+    g["DEFAULT_FLATNESS_TOLERANCE_MM"] = b["flatness_tolerance_mm"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Draft_Angle"] = b["draft_angle_deg"]
+    g["Engraving_Depth"] = b["engraving_depth_mm"]
+    g["Minkowski_Multiplier"] = b["minkowski_multiplier"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Corner_Fn"] = q["corner_fn"]
+    g["Wing_Fn"] = q["wing_fn"]
+    g["Platen_Fn"] = q["platen_fn"]
+    g["Minkowski_Fn"] = q["minkowski_fn"]
+    g["Loop_Fn"] = q["loop_fn"]
+    g["Loop_Tube_Fn"] = q["loop_tube_fn"]
+    g["Post_Fn"] = q["post_fn"]
+    g["Side_Hole_Fn"] = q["side_hole_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+    g["Raft_Thickness"] = r["raft_thickness_mm"]
+    g["Wire_Thickness"] = r["wire_thickness_mm"]
+    g["Support_Height"] = r["support_height_mm"]
+    g["Support_Pitch"] = r["support_pitch_mm"]
+
+    gauge = cfg["gauge"]
+    g["Gauge_Enabled"] = gauge["gauge_enabled"]
+    g["Gauge_Fine_Pitch_Mm"] = gauge["fine_pitch_mm"]
+    g["Gauge_Major_Pitch_Mm"] = gauge["major_pitch_mm"]
+    g["Gauge_Hole_D_Mm"] = gauge["hole_d_mm"]
+    g["Gauge_Fine_Z_Mm"] = gauge["fine_z_mm"]
+    g["Gauge_Major_Z_Mm"] = gauge["major_z_mm"]
+    g["Gauge_Hole_Fn"] = gauge["hole_fn"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    tt = cfg.get("type_test", {})
+    g["Test_CPI"] = tt.get("cpi", 10.0)
+    g["Test_String_Custom"] = tt.get("text", "")
+
+    _configured = True
+    wing_slug._receive_config(g, "type_slug")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call type_slug.configure(config_path) before using this module")

--- a/v4/lib/vogue_slug.py
+++ b/v4/lib/vogue_slug.py
@@ -1,0 +1,140 @@
+"""
+v4 Vogue Slug - ports v1/Type Slugs/VogueSlug.scad, the faithful replica
+(modeled from real drawings) carrying the real 2-piece "Vogue Foundry"
+mark (arrow + V, imported from vogue-foundry-arrow.svg/vogue-foundry-
+v.svg) plus its own True_Vogue typeface default. Shares lib/wing_slug.py's
+engine with lib/type_slug.py/lib/gauge_slug.py - see that module's
+docstring for the shared geometry pipeline and the v1-is-ground-truth
+callout (VogueSlug.scad was never carried into v2 either).
+
+All real numbers live in config/vogue_slug.yaml - call configure(path)
+once before using anything else in this module (see generate.py).
+"""
+
+import yaml
+
+import wing_slug
+from wing_slug import FullElement, ResinPrint, Additive  # re-exported for callers
+
+_configured = False
+
+
+def configure(config_path):
+    global _configured
+    with open(config_path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    g = globals()
+    g["CONFIG"] = cfg
+    g["z"] = 0.001
+
+    font = cfg["font"]
+    g["FONT_PATH"] = font["path"]
+    g["Font_Size"] = font["size_mm"]
+
+    align = cfg["alignment"]
+    g["Align_Mode"] = align["mode"]
+    g["Align_Center_Offset_Mm"] = align["center_offset_mm"]
+    g["Align_Left_Offset_Mm"] = align["left_offset_mm"]
+    g["Align_Modified_Left_Chars"] = align["modified_left_chars"]
+    g["Align_Modified_Left_Offset_Mm"] = align["modified_left_offset_mm"]
+    g["Align_Modified_Right_Chars"] = align["modified_right_chars"]
+    g["Align_Modified_Right_Offset_Mm"] = align["modified_right_offset_mm"]
+
+    char = cfg["character"]
+    g["Character_Enabled"] = char["char_enabled"]
+    g["Lower_Char"] = char["lower_char"]
+    g["Upper_Char"] = char["upper_char"]
+
+    logo = cfg["logo"]
+    g["Logo_Enabled"] = logo["logo_enabled"]
+    g["Logo_Svg_File"] = logo["svg_file"]
+    g["Logo_Scale_Mm_Per_Unit"] = logo["scale_mm_per_unit"]
+    g["Logo_Depth_Mm"] = logo["logo_depth_mm"]
+    g["Logo_Location"] = logo["location_frac"]
+    g["Logo_Vogue_Enabled"] = logo["vogue_enabled"]
+    g["Vogue_Arrow_Svg_File"] = logo["vogue_arrow_svg_file"]
+    g["Vogue_V_Svg_File"] = logo["vogue_v_svg_file"]
+
+    lbl = cfg["label"]
+    g["Copyright_Text"] = lbl["text"]
+    g["Copyright_Font"] = lbl["font_path"]
+    g["Copyright_Depth"] = lbl["label_depth_mm"]
+
+    e = cfg["element"]
+    g["Body_Width"] = e["body_width_mm"]
+    g["Body_Length"] = e["body_length_mm"]
+    g["Body_Height"] = e["body_height_mm"]
+    g["Face_Thickness"] = e["face_thickness_mm"]
+    g["Face_Radius"] = e["face_radius_mm"]
+    g["Wing_Radius"] = e["wing_radius_mm"]
+    g["Platen_Shift_Motion"] = e["platen_shift_motion_mm"]
+    g["Baselines_Shift_Motion"] = e["baselines_shift_motion_mm"]
+    g["Body_Slot_Width"] = e["body_slot_width_mm"]
+    g["Wing_Thickness"] = e["wing_thickness_mm"]
+    g["Aligning_Cut"] = e["aligning_cut_mm"]
+    g["Baseline"] = e["baseline_mm"]
+    g["Platen_Diameter"] = e["platen_diameter_mm"]
+    g["Bottom_Thickness"] = e["bottom_thickness_mm"]
+    g["Upper_Wing_Angle"] = e["upper_wing_angle_deg"]
+    g["Lower_Wing_Angle"] = e["lower_wing_angle_deg"]
+    g["Element_Loop_Enabled"] = e["loop_enabled"]
+    g["Loop_Thickness"] = e["loop_thickness_mm"]
+    g["Loop_Diameter"] = e["loop_diameter_mm"]
+    g["Loop_Rotation"] = e["loop_rotation_deg"]
+    g["Element_Post_Enabled"] = e["post_enabled"]
+    g["Post_ID"] = e["post_id_mm"]
+    g["Post_OD"] = e["post_od_mm"]
+    g["Element_Side_Hole_Enabled"] = e["side_hole_enabled"]
+    g["Side_Hole_ID"] = e["side_hole_id_mm"]
+    g["Side_Hole_Height"] = e["side_hole_height_frac"]
+
+    b = cfg["build"]
+    g["DEFAULT_FLATNESS_TOLERANCE_MM"] = b["flatness_tolerance_mm"]
+    g["DEFAULT_MINKOWSKI_ENABLED"] = b["minkowski_enabled"]
+    g["Draft_Angle"] = b["draft_angle_deg"]
+    g["Engraving_Depth"] = b["engraving_depth_mm"]
+    g["Minkowski_Multiplier"] = b["minkowski_multiplier"]
+    g["Character_Block_Height_Mm"] = b["character_block_height_mm"]
+    g["DEFAULT_RESIN_SUPPORT"] = b["resin_support"]
+
+    q = cfg["quality"]
+    g["Corner_Fn"] = q["corner_fn"]
+    g["Wing_Fn"] = q["wing_fn"]
+    g["Platen_Fn"] = q["platen_fn"]
+    g["Minkowski_Fn"] = q["minkowski_fn"]
+    g["Loop_Fn"] = q["loop_fn"]
+    g["Loop_Tube_Fn"] = q["loop_tube_fn"]
+    g["Post_Fn"] = q["post_fn"]
+    g["Side_Hole_Fn"] = q["side_hole_fn"]
+
+    r = cfg["resin"]
+    g["Resin_Fn"] = r["resin_fn"]
+    g["Raft_Thickness"] = r["raft_thickness_mm"]
+    g["Wire_Thickness"] = r["wire_thickness_mm"]
+    g["Support_Height"] = r["support_height_mm"]
+    g["Support_Pitch"] = r["support_pitch_mm"]
+
+    gauge = cfg["gauge"]
+    g["Gauge_Enabled"] = gauge["gauge_enabled"]
+    g["Gauge_Fine_Pitch_Mm"] = gauge["fine_pitch_mm"]
+    g["Gauge_Major_Pitch_Mm"] = gauge["major_pitch_mm"]
+    g["Gauge_Hole_D_Mm"] = gauge["hole_d_mm"]
+    g["Gauge_Fine_Z_Mm"] = gauge["fine_z_mm"]
+    g["Gauge_Major_Z_Mm"] = gauge["major_z_mm"]
+    g["Gauge_Hole_Fn"] = gauge["hole_fn"]
+
+    g["OUTPUT_DIR"] = cfg["output"]["directory"]
+    g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
+
+    tt = cfg.get("type_test", {})
+    g["Test_CPI"] = tt.get("cpi", 10.0)
+    g["Test_String_Custom"] = tt.get("text", "")
+
+    _configured = True
+    wing_slug._receive_config(g, "vogue_slug")
+
+
+def _require_configured():
+    if not _configured:
+        raise RuntimeError("call vogue_slug.configure(config_path) before using this module")

--- a/v4/lib/wing_slug.py
+++ b/v4/lib/wing_slug.py
@@ -1,0 +1,544 @@
+"""
+Shared "wing body" type-slug engine - lib/type_slug.py (generic base
+engine), lib/vogue_slug.py (Vogue foundry mark replica), and lib/
+gauge_slug.py (no-text calibration/measuring gauge) all configure this
+module and share everything here, the same "shared engine + thin per-
+variant module" pattern lib/spherical_machine.py uses for lib/
+selectric12.py/selectric3.py/selectric_composer.py.
+
+Ground truth is v1, not v2: these standalone decorative type-slug
+replicas (v1/Type Slugs/*.scad) were never carried into v2 at all (v2's
+whole file set is the 7 real typewriter-machine ports, unrelated) - so
+"the real v2 source is ground truth" (CLAUDE.md's usual convention)
+doesn't apply here; v1/Type Slugs/TypeSlug.scad is the ground truth this
+module and config/type_slug.yaml/vogue_slug.yaml/gauge_slug.yaml are
+ported from, cross-referenced by v1 line number the same way v2 line
+numbers are used for every other machine.
+
+Physical form: NOT a full keyboard/typewriter assembly - one small,
+individually-molded/printed type slug (the actual metal-type-style
+element a typebar or shuttle carries), novelty/reference objects rather
+than functional typewriter parts (except Gauge, see lib/gauge_slug.py's
+docstring - a real install-on-the-machine measuring tool, not a novelty).
+Because of that, there is no keyboard "layout" (row/column grid) concept
+at all - config has no `layout:` section, so tune.py's `"rows" in
+layout` check (HAS_LAYOUT_TAB) is naturally False and the Layout tab is
+skipped, same mechanism Selectric already relies on for ITS "no editable
+keyboard-layout concept" callout, not new/special-cased code.
+
+Function-by-function relationship to v1/Type Slugs/TypeSlug.scad's
+MakeSlug() (lines 108-287), verified before writing any of this (per
+CLAUDE.md's "diff against source first" rule):
+  - BodyHull()/EnvelopeHull() -> the nested hull(){...} body construction
+    (lines 115-134, duplicated at 184-206 for the enlarged envelope) -
+    both are really just ONE convex hull of the same 6 primitives (4
+    corner posts + 2 wing cylinders) at two different corner-post
+    heights; v1's own INNER hull() (around just the 4 corners) is
+    redundant once everything funnels into a single outer convex hull
+    (hull() is idempotent - convex_hull(convex_hull(A) u B) ==
+    convex_hull(A u B)), so this module only ever builds ONE real
+    trimesh.convex_hull per call, not two nested ones.
+  - DraftText() -> "Create Draft Angle Text" (lines 158-181) - two
+    stacked struck characters (not build_glyph()'s one-character-per-row
+    model; genuinely different real geometry, ported fresh here rather
+    than forced through build_glyph, same reasoning spherical_machine's
+    own module docstring gives for not reusing build_glyph either).
+  - Logo()/VogueMark() -> "SVG Logo" (135-146)/VogueSlug.scad's "Vogue
+    Foundry Mark" (109-126) - TypeSlug.scad's OWN "SVG_Vogue_Enable"
+    branch (147-157) is a byte-for-byte duplicate of its SVG_Enable
+    branch (same SVG_File, not the real vogue-foundry-*.svg files) - i.e.
+    dead/redundant leftover from when VogueSlug.scad was forked off of
+    it, not a second real feature. NOT ported as a second toggle here;
+    logo.vogue_enabled (this module's real 2-piece Vogue mark, matching
+    VogueSlug.scad's actual working code) is the only "second logo"
+    concept that exists.
+  - _clean_exposed_minkowski() -> "Clean Exposed Minkowski Manifold"
+    (152-176) - v1 builds this as `(box20 - envelope)` then subtracts
+    THAT from the drafted union; implemented here as a direct
+    intersection with the envelope instead (equivalent whenever the
+    drafted union doesn't extend past the local 20mm box, true for every
+    real config here - a small, explicitly-noted simplification, not a
+    behavior change).
+  - TypebarSlot()/CopyrightText() -> 208-220.
+  - ResinSupportGeometry() -> "Resin Support" (223-245) - v1's own
+    raft+per-station-wire construction, genuinely different from
+    lib/resin_support.py's resin_rod() (single hull-of-3-spheres capsule
+    per rod, individual per-rod raft) - NOT force-fit onto that shared
+    helper, same "real new lib code when the real geometry differs"
+    reasoning CLAUDE.md's geometry-invariants section already establishes
+    for Hammond Split's own independent resin-support scheme.
+  - Loop() -> "Loop" (247-254) - a torus (rotate_extrude of a small
+    offset circle), built via scad_primitives.revolve_polygon like every
+    other machine's torus/ring features.
+  - Post()/PostHole() -> "Post and Hole" (256-273, 275-279).
+  - SideHole() -> "Side Holes" (281-285).
+  - Ticks() (gauge_slug.py's own no-text variant) ->
+    v1/Type Slugs/GaugeTypeSlugSlug.scad:104-112 - NOT part of
+    TypeSlug.scad at all; lives here anyway (not gauge_slug.py) since
+    it's config-driven (gauge.enabled) like every other optional feature
+    in this shared engine, matching the "shared code lives in the
+    shared module" convention.
+
+Resin support is a build.resin_support TOGGLE (ResinPrint vs FullElement
+dispatch, same convention every other v4 machine uses), NOT baked
+permanently into the geometry the way v1's single `Resin_Support`
+customizer variable was - a real, deliberate structural improvement
+(cleanly separates "is this a resin print" from the element's own
+geometry), not a silent behavior change: build.resin_support: true
+reproduces v1's Resin_Support=true default exactly.
+"""
+
+import time
+
+import numpy as np
+import trimesh
+from manifold3d import Manifold
+from shapely.geometry import Polygon as ShapelyPolygon, Point as ShapelyPoint
+
+from glyph_poc import (get_glyph_contours_and_advance, classify_and_triangulate,
+                        alignment_x_offset, em_to_mm_scale, load_font_face)
+import scad_primitives as sp
+import svg_import
+import build_log
+
+_active_machine = None
+
+
+def _receive_config(source_globals, machine_name):
+    global _active_machine
+    if _active_machine not in (None, machine_name):
+        raise RuntimeError(
+            f"wing_slug already configured for {_active_machine!r}; "
+            f"cannot reconfigure for {machine_name!r} in the same process")
+    _active_machine = machine_name
+    globals().update({k: v for k, v in source_globals.items() if k[:1].isupper() or k == "z"})
+
+
+def _require_configured():
+    if _active_machine is None:
+        raise RuntimeError("call <machine>.configure(config_path) before using this module")
+
+
+# ------------------------------------------------------------------ Body
+
+def _corner_post_verts(corner_height, fn):
+    """The 4 rounded-corner posts of the body's flat base face (v1:118-125/
+    190-197), pre-translate (spans z=[0, corner_height] each) - the -
+    Face_Thickness Z shift (v1's outer `translate([0,0,-Face_Thickness])`
+    wrapping the inner hull()) is applied by the caller once, to the
+    combined point cloud, not per-post."""
+    positions = [
+        (-Body_Width / 2 + Face_Radius, Face_Radius),
+        (Body_Width / 2 - Face_Radius, Face_Radius),
+        (Body_Width / 2 - Face_Radius, Body_Length - Face_Radius),
+        (-Body_Width / 2 + Face_Radius, Body_Length - Face_Radius),
+    ]
+    verts = []
+    for x, y in positions:
+        post = sp.cylinder_z(2 * Face_Radius, corner_height, sections=Corner_Fn, base_z=0.0)
+        post.apply_translation([x, y, 0.0])
+        verts.append(post.vertices)
+    return np.concatenate(verts, axis=0)
+
+
+def _wing_cyl_verts(y_pos):
+    """One wing cylinder (v1:128-130/131-133, 200-205) - axis along X
+    (rotate([0,90,0])), radius Wing_Radius, length Body_Slot_Width+2*
+    Wing_Thickness, at (0, y_pos, -Body_Height+Wing_Radius)."""
+    cyl = trimesh.creation.cylinder(radius=Wing_Radius, height=Body_Slot_Width + 2 * Wing_Thickness,
+                                     sections=Wing_Fn)
+    cyl = sp.scad_transform(cyl, ("translate", [0, y_pos, -Body_Height + Wing_Radius]),
+                             ("rotate", [0, 90, 0]))
+    return cyl.vertices
+
+
+def _body_hull(corner_height):
+    """hull() of the 4 corner posts (at z=[-Face_Thickness, -Face_Thickness
+    +corner_height]) and the 2 wing cylinders - see module docstring for
+    why this is ONE convex_hull() call, not v1's nested hull()s."""
+    _require_configured()
+    corner_v = _corner_post_verts(corner_height, Corner_Fn)
+    corner_v = corner_v.copy()
+    corner_v[:, 2] -= Face_Thickness
+    lower_y = (Body_Height - Wing_Radius) * np.sin(np.radians(Lower_Wing_Angle)) + Wing_Radius
+    upper_y = Body_Length - (Body_Height - Wing_Radius) * np.sin(np.radians(Upper_Wing_Angle)) - Wing_Radius
+    all_v = np.concatenate([corner_v, _wing_cyl_verts(lower_y), _wing_cyl_verts(upper_y)], axis=0)
+    return trimesh.Trimesh(vertices=all_v, process=True).convex_hull
+
+
+def BodyHull():
+    return _body_hull(Face_Thickness)
+
+
+def EnvelopeHull():
+    """The enlarged envelope used only to clip drafted-text/logo overflow
+    back to the body's own footprint (v1's "Clean Exposed Minkowski
+    Manifold", 184-206) - corner posts extended to Face_Thickness+10 tall
+    (see module docstring's _clean_exposed_minkowski note)."""
+    return _body_hull(Face_Thickness + 10.0)
+
+
+# -------------------------------------------------------------- Draft text
+
+def _draft_cone(cone_segments=None, draft_angle_deg=None):
+    """v1's draft cone (e.g. 178-180): cylinder(h=Engraving_Depth*
+    Minkowski_Multiplier, r1=sin(Draft_Angle)*that height, r2=0),
+    translated so its APEX sits at z=0 and its wide base at z=-h - same
+    "widen toward the root" construction glyph_poc.build_glyph() uses,
+    but v1's OWN real formula (sin(Draft_Angle), not build_glyph's
+    cylinder-family tan(half-angle) formula) - a real, different physical
+    model, ported as-is rather than reconciled with build_glyph's.
+    cone_segments/draft_angle_deg override config's quality.minkowski_fn/
+    build.draft_angle_deg when given, matching generate.py's uniform
+    per-call CLI-override convention (threaded explicitly, not via global
+    mutation - see lib/bennett.py/lib/mignon.py for the same idiom)."""
+    fn = Minkowski_Fn if cone_segments is None else cone_segments
+    angle = Draft_Angle if draft_angle_deg is None else draft_angle_deg
+    h = Engraving_Depth * Minkowski_Multiplier
+    r1 = np.sin(np.radians(angle)) * h
+    cone = Manifold.cylinder(h, r1, 0.0, circular_segments=fn)
+    return cone.translate([0, 0, -h])
+
+
+def _platen_cyl_pair(y_pos, platen_fn=None):
+    """The 2-cylinder platen cutout (e.g. v1:169-175) - built in local
+    (pre-rotate) space, THEN rotate([0,90,0])+translate([0,y_pos,
+    Engraving_Depth+Platen_Diameter/2]) applied to both, matching v1's
+    `translate(...) rotate(...) { cylinder(); translate(...) cylinder();
+    }` child order exactly (rotate is the INNER op, translate OUTER -
+    scad_transform's own documented top-to-bottom convention)."""
+    fn = Platen_Fn if platen_fn is None else platen_fn
+    c1 = trimesh.creation.cylinder(radius=Platen_Diameter / 2.0, height=Body_Width, sections=fn)
+    c2 = sp.translate(c1.copy(), [0, Platen_Shift_Motion, 0])
+    return [sp.scad_transform(m, ("translate", [0, y_pos, Engraving_Depth + Platen_Diameter / 2.0]),
+                               ("rotate", [0, 90, 0]))
+            for m in (c1, c2)]
+
+
+def _align_kwargs():
+    return dict(mode=Align_Mode, center_offset_mm=Align_Center_Offset_Mm,
+                left_offset_mm=Align_Left_Offset_Mm,
+                modified_left_chars=Align_Modified_Left_Chars,
+                modified_left_offset_mm=Align_Modified_Left_Offset_Mm,
+                modified_right_chars=Align_Modified_Right_Chars,
+                modified_right_offset_mm=Align_Modified_Right_Offset_Mm)
+
+
+def DraftText(flatness_tolerance_mm=None, minkowski_enabled=None, draft_angle_deg=None,
+              cone_segments=None, platen_fn=None):
+    """"Create Draft Angle Text" (v1:158-181) - Lower_Char at y=Baseline,
+    Upper_Char at y=Baseline+Baselines_Shift_Motion, both mirrored
+    together (matches v1's mirror([1,0,0]) wrapping both children, and
+    build_glyph()'s own shift-then-mirror order), unioned into ONE flat
+    2D shape, platen-cut (2 real boolean cylinders, BEFORE the Minkowski
+    sum per CLAUDE.md's curvature-before-Minkowski invariant), then
+    Minkowski-summed with _draft_cone()."""
+    _require_configured()
+    flatness_tolerance_mm = DEFAULT_FLATNESS_TOLERANCE_MM if flatness_tolerance_mm is None else flatness_tolerance_mm
+    minkowski_enabled = DEFAULT_MINKOWSKI_ENABLED if minkowski_enabled is None else minkowski_enabled
+
+    face = load_font_face(FONT_PATH)
+    scale = em_to_mm_scale(Font_Size, face.units_per_EM)
+    align_kwargs = _align_kwargs()
+    contours = []
+    for ch, y in ((Lower_Char, Baseline), (Upper_Char, Baseline + Baselines_Shift_Motion)):
+        c_contours, advance_mm = get_glyph_contours_and_advance(ch, flatness_tolerance_mm, scale, font_path=FONT_PATH)
+        x_shift = alignment_x_offset(ch, advance_mm, **align_kwargs)
+        for c in c_contours:
+            contours.append(c + np.array([x_shift, y]))
+    contours = [c * np.array([-1.0, 1.0]) for c in contours]  # mirror([1,0,0]) - struck character
+
+    flat = classify_and_triangulate(contours)
+    prism = trimesh.creation.extrude_triangulation(flat.vertices[:, :2], flat.faces, Character_Block_Height_Mm)
+
+    scalloped = sp.to_manifold(prism)
+    for cutter in _platen_cyl_pair(Aligning_Cut, platen_fn=platen_fn):
+        scalloped = scalloped - sp.to_manifold(cutter)
+
+    if not minkowski_enabled:
+        return sp.from_manifold(scalloped)
+
+    drafted = scalloped.minkowski_sum(_draft_cone(cone_segments=cone_segments, draft_angle_deg=draft_angle_deg))
+    return sp.from_manifold(drafted)
+
+
+# ------------------------------------------------------------------- Logo
+
+def _minkowski_draft_flat2d(flat_mesh, block_height_mm, minkowski_enabled, cone_segments=None, draft_angle_deg=None):
+    """Shared by Logo()/VogueMark(): extrude a flat 2D triangulated shape
+    to block_height_mm, Minkowski-sum with the SAME _draft_cone()
+    construction DraftText() uses (v1 reuses the identical Engraving_
+    Depth*Minkowski_Multiplier/Draft_Angle cone for its SVG logo(s) too -
+    e.g. v1:142-145/153-156/122-125)."""
+    prism = trimesh.creation.extrude_triangulation(flat_mesh.vertices[:, :2], flat_mesh.faces, block_height_mm)
+    if not minkowski_enabled:
+        return prism
+    drafted = sp.to_manifold(prism).minkowski_sum(_draft_cone(cone_segments=cone_segments, draft_angle_deg=draft_angle_deg))
+    return sp.from_manifold(drafted)
+
+
+def Logo(flatness_tolerance_mm=None, minkowski_enabled=None, cone_segments=None, draft_angle_deg=None):
+    """"SVG Logo" (v1:135-146) - one imported SVG, scaled/positioned along
+    the body's centerline at Body_Length*SVG_Location, Minkowski-drafted
+    same as the struck text."""
+    _require_configured()
+    flatness_tolerance_mm = DEFAULT_FLATNESS_TOLERANCE_MM if flatness_tolerance_mm is None else flatness_tolerance_mm
+    minkowski_enabled = DEFAULT_MINKOWSKI_ENABLED if minkowski_enabled is None else minkowski_enabled
+    flat = svg_import.build_svg_logo_mesh_2d(
+        [Logo_Svg_File], flatness_tolerance_mm, Logo_Scale_Mm_Per_Unit,
+        offsets=[(0.0, Body_Length * Logo_Location)])
+    return _minkowski_draft_flat2d(flat, Logo_Depth_Mm, minkowski_enabled,
+                                    cone_segments=cone_segments, draft_angle_deg=draft_angle_deg)
+
+
+def VogueMark(flatness_tolerance_mm=None, minkowski_enabled=None, cone_segments=None, draft_angle_deg=None):
+    """"Vogue Foundry Mark" (v1/VogueSlug.scad:109-126) - the real
+    2-piece arrow+V mark, each with its own offset, drafted together as
+    ONE combined swept solid (see svg_import.build_svg_logo_mesh_2d's own
+    docstring for why the offsets are applied before triangulation, not
+    after)."""
+    _require_configured()
+    flatness_tolerance_mm = DEFAULT_FLATNESS_TOLERANCE_MM if flatness_tolerance_mm is None else flatness_tolerance_mm
+    minkowski_enabled = DEFAULT_MINKOWSKI_ENABLED if minkowski_enabled is None else minkowski_enabled
+    y0 = Body_Length * Logo_Location
+    flat = svg_import.build_svg_logo_mesh_2d(
+        [Vogue_Arrow_Svg_File, Vogue_V_Svg_File], flatness_tolerance_mm, Logo_Scale_Mm_Per_Unit,
+        offsets=[(0.2, y0 - 0.5), (-0.5, y0 - 1.2)])
+    return _minkowski_draft_flat2d(flat, Logo_Depth_Mm, minkowski_enabled,
+                                    cone_segments=cone_segments, draft_angle_deg=draft_angle_deg)
+
+
+# --------------------------------------------------------------- Cleanup
+
+def _clean_exposed_minkowski(core):
+    """"Clean Exposed Minkowski Manifold" (v1:152-176) - see module
+    docstring for why this is a direct intersection with EnvelopeHull()
+    rather than v1's own box-minus-envelope subtraction."""
+    return core.intersection(EnvelopeHull(), engine="manifold")
+
+
+# --------------------------------------------------------------- Cutters
+
+def TypebarSlot():
+    """v1:208-210."""
+    _require_configured()
+    return sp.box_centered([Body_Slot_Width, Body_Length + 1, Body_Height + 1],
+                            [0, Body_Length / 2.0, -Bottom_Thickness - (Body_Height + 1) / 2.0])
+
+
+def CopyrightText():
+    """Engraved copyright text on the side face (v1:217-220 - the working
+    block; the commented-out 212-215 alternative is dead in the real
+    source and not ported). Left-to-right natural-advance layout,
+    centered, matching spherical_machine.Labels()'s own convention for a
+    plain engraved string."""
+    _require_configured()
+    if not Copyright_Text:
+        return None
+    face = load_font_face(Copyright_Font)
+    scale = em_to_mm_scale(Body_Slot_Width * 0.75, face.units_per_EM)
+    cursor = 0.0
+    parts = []
+    for ch in Copyright_Text:
+        if ch == " ":
+            cursor += Body_Slot_Width * 0.75 * 0.3
+            continue
+        try:
+            _, adv = get_glyph_contours_and_advance(ch, DEFAULT_FLATNESS_TOLERANCE_MM, scale, font_path=Copyright_Font)
+        except Exception as e:
+            print(f"CopyrightText: skipping {ch!r} ({e})", flush=True)
+            continue
+        from glyph_poc import build_flat_text
+        m = build_flat_text(ch, DEFAULT_FLATNESS_TOLERANCE_MM, Copyright_Depth + 0.01,
+                             font_size_mm=Body_Slot_Width * 0.75, font_path=Copyright_Font)
+        parts.append(sp.translate(m, [cursor, 0, 0]))
+        cursor += adv
+    if not parts:
+        return None
+    text_mesh = sp.translate(sp.union_all(parts), [-cursor / 2.0, 0, 0])
+    return sp.scad_transform(
+        text_mesh,
+        ("translate", [Body_Width / 2.0 - Copyright_Depth, Body_Length / 2.0, -Face_Thickness + 0.1]),
+        ("rotate", [90, 0, 90]))
+
+
+def Ticks():
+    """Gauge tick-hole ladder (gauge_slug.py only - v1/Type Slugs/
+    GaugeTypeSlugSlug.scad:104-112). Two independent rows of same-
+    diameter side-drilled holes at different Z heights: a fine row every
+    Gauge_Fine_Pitch_Mm, a coarser row every Gauge_Major_Pitch_Mm - both
+    usable as measurement graduations once installed on the real
+    machine (this is the ONE real functional/measuring variant of this
+    family - see lib/gauge_slug.py's module docstring)."""
+    _require_configured()
+    holes = []
+    n = np.arange(0.0, Body_Length + 1e-9, Gauge_Fine_Pitch_Mm)
+    for y in n:
+        c = sp.cylinder_z(Gauge_Hole_D_Mm, Body_Height + 0.001, sections=Gauge_Hole_Fn, base_z=Gauge_Fine_Z_Mm)
+        holes.append(sp.translate(c, [-Body_Width / 2.0, y, 0]))
+    n2 = np.arange(Gauge_Major_Pitch_Mm, Body_Length + 1e-9, Gauge_Major_Pitch_Mm)
+    for y in n2:
+        c = sp.cylinder_z(Gauge_Hole_D_Mm, Body_Height + 0.001, sections=Gauge_Hole_Fn, base_z=Gauge_Major_Z_Mm)
+        holes.append(sp.translate(c, [-Body_Width / 2.0, y, 0]))
+    return sp.union_all(holes)
+
+
+def PostHole():
+    _require_configured()
+    c = trimesh.creation.cylinder(radius=Post_ID / 2.0, height=10.0, sections=Post_Fn)
+    c = sp.scad_transform(c, ("translate", _post_coords()), ("rotate", [0, 90, 0]))
+    return c
+
+
+def SideHole():
+    _require_configured()
+    c = trimesh.creation.cylinder(radius=Side_Hole_ID / 2.0, height=10.0, sections=Side_Hole_Fn)
+    hole_coords = [0, Body_Length - (Body_Height * Side_Hole_Height) * np.sin(np.radians(Upper_Wing_Angle)) - Side_Hole_ID,
+                   -Body_Height * Side_Hole_Height]
+    return sp.scad_transform(c, ("translate", hole_coords), ("rotate", [0, 90, 0]))
+
+
+# -------------------------------------------------------- Additive extras
+
+def _post_coords():
+    return [0, Body_Length - (Body_Height - Wing_Radius) * np.sin(np.radians(Upper_Wing_Angle)) - Wing_Radius,
+            -Body_Height + Wing_Radius]
+
+
+def Loop():
+    """"Loop" (v1:247-254) - a torus, via scad_primitives.torus() (shared
+    with lib/box_slug.py's identical Loop() recipe)."""
+    _require_configured()
+    ring = sp.torus(Loop_Diameter / 2.0 - Loop_Thickness / 2.0, Loop_Thickness,
+                     sections=Loop_Fn, tube_sections=Loop_Tube_Fn)
+    return sp.scad_transform(ring, ("translate", [0, Body_Length, -Loop_Thickness / 2.0]),
+                              ("rotate", [0, Loop_Rotation, 0]))
+
+
+def Post():
+    """"Post and Hole" (v1:256-273) - a small rounded-boss nub via
+    shapely (rectangle minus a corner circle, matching v1's
+    polygon()-minus-circle profile), revolved."""
+    _require_configured()
+    r_out = Post_ID / 2.0 + Post_OD / 2.0 + Body_Slot_Width / 2.0
+    rect = ShapelyPolygon([(Post_ID / 2.0, 0), (Post_ID / 2.0, Body_Slot_Width),
+                            (r_out, Body_Slot_Width), (r_out, 0)])
+    corner = ShapelyPoint(r_out, Body_Slot_Width / 2.0).buffer(Body_Slot_Width / 2.0, resolution=Post_Fn // 4)
+    profile_poly = rect.difference(corner)
+    profile = list(profile_poly.exterior.coords)
+    boss = sp.revolve_polygon(profile, sections=Post_Fn)
+    return sp.scad_transform(boss, ("translate", _post_coords()),
+                              ("translate", [-Body_Slot_Width / 2.0, 0, 0]), ("rotate", [0, 90, 0]))
+
+
+def ResinSupportGeometry():
+    """"Resin Support" (v1:223-245) - a sloped raft plate (hull of 2
+    parallel rects at different Z/XY size) plus per-station wire+taper+
+    tip-sphere supports along both sides of the typebar slot. See module
+    docstring for why this doesn't reuse resin_support.resin_rod()."""
+    _require_configured()
+    raft_top = sp.box_centered([Body_Width + 4, Body_Length + 4, 0.001],
+                                [0, Body_Length / 2.0, -Body_Height - Support_Height])
+    raft_bottom = sp.box_centered([Body_Width, Body_Length, 0.001],
+                                   [0, Body_Length / 2.0, -Body_Height - Support_Height - Raft_Thickness])
+    raft = trimesh.Trimesh(vertices=np.concatenate([raft_top.vertices, raft_bottom.vertices]),
+                            process=True).convex_hull
+
+    parts = [raft]
+    y_start = (Body_Height - Wing_Radius) * np.sin(np.radians(Lower_Wing_Angle)) + Wing_Radius
+    y_end = Body_Length - (Body_Height - Wing_Radius) * np.sin(np.radians(Upper_Wing_Angle)) - Wing_Radius
+    for y in np.arange(y_start, y_end + 1e-9, Support_Pitch):
+        for side in (1.0, -1.0):
+            x = side * (Body_Slot_Width / 2.0 + Wing_Thickness / 2.0)
+            z0 = -Body_Height - Support_Height
+            wire = sp.cylinder_z(Wire_Thickness, Support_Height - 1.0, sections=Resin_Fn, base_z=z0)
+            taper = sp.frustum_z(Wire_Thickness, 0.3, 1.0, sections=Resin_Fn, base_z=z0 + Support_Height - 1.0)
+            tip = trimesh.creation.icosphere(subdivisions=2, radius=0.15)
+            tip.apply_translation([0, 0, z0 + Support_Height])
+            station = trimesh.util.concatenate([wire, taper, tip])
+            parts.append(sp.translate(station, [x, y, 0]))
+    return sp.union_all(parts)
+
+
+# ------------------------------------------------------------------ Element
+
+def _assemble_core(flatness_tolerance_mm, minkowski_enabled, draft_angle_deg, cone_segments, platen_fn):
+    parts = [BodyHull()]
+    drafted_any = False
+    if Character_Enabled:
+        parts.append(DraftText(flatness_tolerance_mm=flatness_tolerance_mm,
+                                minkowski_enabled=minkowski_enabled, draft_angle_deg=draft_angle_deg,
+                                cone_segments=cone_segments, platen_fn=platen_fn))
+        drafted_any = True
+    if Logo_Enabled:
+        parts.append(Logo(flatness_tolerance_mm=flatness_tolerance_mm, minkowski_enabled=minkowski_enabled,
+                           cone_segments=cone_segments, draft_angle_deg=draft_angle_deg))
+        drafted_any = True
+    if Logo_Vogue_Enabled:
+        parts.append(VogueMark(flatness_tolerance_mm=flatness_tolerance_mm, minkowski_enabled=minkowski_enabled,
+                                cone_segments=cone_segments, draft_angle_deg=draft_angle_deg))
+        drafted_any = True
+    core = sp.union_all(parts)
+    if drafted_any:
+        core = _clean_exposed_minkowski(core)
+    return core
+
+
+def Additive(flatness_tolerance_mm=None, separation_mm=None, render_core_groove=None,
+             cone_segments=None, platen_fn=None, minkowski_enabled=None, draft_angle_deg=None):
+    """separation_mm/render_core_groove are accepted-but-ignored - this
+    machine has neither concept (see module docstring's DraftText note
+    and CLAUDE.md's Selectric precedent for this exact pattern).
+    cone_segments/platen_fn are threaded explicitly down to _draft_cone/
+    _platen_cyl_pair (falling back to config's quality.minkowski_fn/
+    platen_fn only at that point of use), matching lib/bennett.py's/lib/
+    mignon.py's own idiom - not a global-mutation override."""
+    _require_configured()
+    parts = [_assemble_core(flatness_tolerance_mm, minkowski_enabled, draft_angle_deg, cone_segments, platen_fn)]
+    if Element_Loop_Enabled:
+        parts.append(Loop())
+    if Element_Post_Enabled:
+        parts.append(Post())
+    return sp.union_all(parts)
+
+
+def Subtractive():
+    _require_configured()
+    cutters = [TypebarSlot()]
+    copyright_mesh = CopyrightText()
+    if copyright_mesh is not None:
+        cutters.append(copyright_mesh)
+    if Gauge_Enabled:
+        cutters.append(Ticks())
+    if Element_Post_Enabled:
+        cutters.append(PostHole())
+    if Element_Side_Hole_Enabled:
+        cutters.append(SideHole())
+    return sp.union_all(cutters)
+
+
+def FullElement(flatness_tolerance_mm=None, separation_mm=None, render_core_groove=None,
+                cone_segments=None, platen_fn=None, minkowski_enabled=None, draft_angle_deg=None):
+    _require_configured()
+    additive = Additive(flatness_tolerance_mm=flatness_tolerance_mm, separation_mm=separation_mm,
+                         render_core_groove=render_core_groove, cone_segments=cone_segments,
+                         platen_fn=platen_fn, minkowski_enabled=minkowski_enabled,
+                         draft_angle_deg=draft_angle_deg)
+    result = additive.difference(Subtractive(), engine="manifold")
+    result, _, _, _ = sp.check_and_repair(result, label="FullElement")
+    build_log.mesh_report(result, "FullElement")
+    return result, []
+
+
+def ResinPrint(flatness_tolerance_mm=None, separation_mm=None, render_core_groove=None,
+               cone_segments=None, platen_fn=None, minkowski_enabled=None, draft_angle_deg=None):
+    _require_configured()
+    full, char_parts = FullElement(flatness_tolerance_mm=flatness_tolerance_mm, separation_mm=separation_mm,
+                                    render_core_groove=render_core_groove, cone_segments=cone_segments,
+                                    platen_fn=platen_fn, minkowski_enabled=minkowski_enabled,
+                                    draft_angle_deg=draft_angle_deg)
+    support = ResinSupportGeometry()
+    build_log.mesh_report(support, "ResinSupport")
+    combined = sp.union_all([full, support])
+    combined, _, _, _ = sp.check_and_repair(combined, label="ResinPrint")
+    return combined, char_parts

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -238,21 +238,31 @@ MACHINES = {
     "selectric12": ("Selectric I/II", os.path.join(REPO_ROOT, "config", "selectric12.yaml")),
     "selectric3": ("Selectric III", os.path.join(REPO_ROOT, "config", "selectric3.yaml")),
     "selectric_composer": ("Selectric Composer", os.path.join(REPO_ROOT, "config", "selectric_composer.yaml")),
+    "type_slug": ("Type Slug", os.path.join(REPO_ROOT, "config", "type_slug.yaml")),
+    "vogue_slug": ("Vogue Slug", os.path.join(REPO_ROOT, "config", "vogue_slug.yaml")),
+    "gauge_slug": ("Gauge Slug", os.path.join(REPO_ROOT, "config", "gauge_slug.yaml")),
+    "oliver_slug": ("Oliver Slug", os.path.join(REPO_ROOT, "config", "oliver_slug.yaml")),
+    "lumi_slug": ("Lumi Slug", os.path.join(REPO_ROOT, "config", "lumi_slug.yaml")),
 }
 
 # Groups MACHINES by real-world type-element mechanism (not code-sharing -
 # see CLAUDE.md's "Machine taxonomy" section for why those are different
-# axes) so the machine picker can present 3 short categories instead of
-# one flat wall of 10 buttons. Cylinders = type-wheel machines
+# axes) so the machine picker can present short categories instead of
+# one flat wall of buttons. Cylinders = type-wheel machines
 # (Blickensderfer/Postal/Mignon/Bennett/Helios, per each module's own
 # "cylinder"/"disk" docstring language); Shuttles = the arc-shaped type
 # shuttle (Hammond/Hammond Split, per lib/hammond.py's and lib/
 # hammond_split.py's own "shuttle" docstrings); Spheres = the IBM/
-# Selectric typeball family (lib/spherical_machine.py's docstring).
+# Selectric typeball family (lib/spherical_machine.py's docstring);
+# Slugs = the standalone novelty/reference type-slug replicas (lib/
+# wing_slug.py's/lib/box_slug.py's own docstrings) - not full keyboard/
+# typewriter assemblies like the other three groups, one small element
+# each.
 MACHINE_CATEGORIES = [
     ("Cylinders", ["blickensderfer", "postal", "mignon", "bennett", "helios"]),
     ("Shuttles", ["hammond", "hammond_split"]),
     ("Spheres", ["selectric12", "selectric3", "selectric_composer"]),
+    ("Slugs", ["type_slug", "vogue_slug", "gauge_slug", "oliver_slug", "lumi_slug"]),
 ]
 
 FONT_FILE_FILTERS = Filters(
@@ -1061,6 +1071,155 @@ ELEMENT_FIELDS_SELECTRIC = [
      "v2's own measured reference value, not derived from other fields here."),
 ]
 
+# --- Type Slug family (lib/wing_slug.py + lib/type_slug.py/vogue_slug.py/
+# gauge_slug.py, and lib/box_slug.py + lib/oliver_slug.py/lumi_slug.py) -
+# small standalone novelty/reference type-slug replicas, ground truth is
+# v1 not v2 (see lib/wing_slug.py's/lib/box_slug.py's own module
+# docstrings). No Layout tab (no `layout:` config section - HAS_LAYOUT_
+# TAB is naturally False, same mechanism Selectric's own "no editable
+# keyboard-layout concept" already relies on) and no Calibration tab
+# (CalibrationElement/CalibrationAdditive aren't implemented for this
+# family either - same "deferred" precedent lib/spherical_machine.py's
+# own module docstring sets), so these reuse SECTIONS_COMMON's "Font &
+# Alignment" list ONLY (schema matches exactly - font.path/size_mm,
+# alignment.*, build.draft_angle_deg), not the whole dict spread (which
+# would also pull in "Calibration").
+CHARACTER_FIELDS_WING_SLUG = [
+    ("char_enabled", ["character", "char_enabled"], bool, "Character enabled",
+     "Off for Gauge Slug - no struck character exists in that real v1 source at all."),
+    ("lower_char", ["character", "lower_char"], str, "Lower character", ""),
+    ("upper_char", ["character", "upper_char"], str, "Upper character", ""),
+]
+
+# character.chars (oliver_slug/lumi_slug) is a list (3 items for Oliver,
+# 4 for Lumi, bottom-to-top stack order) - deliberately YAML-only, no
+# tune.py field, per CLAUDE.md's "list-valued config key" convention
+# (option (b): a one-line comment here stands in for the explicit
+# decision, same as layout.placement_map/char_legend elsewhere). Only
+# the two scalar siblings are exposed.
+CHARACTER_FIELDS_BOX_SLUG = [
+    ("baseline_mm", ["character", "baseline_mm"], float, "Baseline (mm)", ""),
+    ("baselines_shift_motion_mm", ["character", "baselines_shift_motion_mm"], float,
+     "Baseline shift per character (mm)", ""),
+]
+
+LOGO_FIELDS_SLUG = [
+    ("logo_enabled", ["logo", "logo_enabled"], bool, "Generic SVG logo enabled",
+     "The AR1.svg-style single-mark logo - off for Vogue Slug/Gauge Slug (see vogue_enabled below for Vogue Slug's own real logo)."),
+    ("svg_file", ["logo", "svg_file"], str, "Logo SVG file", ""),
+    ("scale_mm_per_unit", ["logo", "scale_mm_per_unit"], float, "Logo scale (mm per SVG unit)",
+     "v4-only knob - see lib/svg_import.py's module docstring for why this isn't a port of v1's own SVG_Scale."),
+    ("logo_depth_mm", ["logo", "logo_depth_mm"], float, "Logo engraving depth (mm)", ""),
+    ("location_frac", ["logo", "location_frac"], float, "Logo position (fraction of body length)", ""),
+    ("vogue_enabled", ["logo", "vogue_enabled"], bool, "Vogue Foundry mark enabled",
+     "The real 2-piece arrow+V mark - only ever on for Vogue Slug."),
+    ("vogue_arrow_svg_file", ["logo", "vogue_arrow_svg_file"], str, "Vogue arrow SVG file", ""),
+    ("vogue_v_svg_file", ["logo", "vogue_v_svg_file"], str, "Vogue V SVG file", ""),
+]
+
+LABEL_FIELDS_SLUG = [
+    ("text", ["label", "text"], str, "Copyright text", ""),
+    ("font_path", ["label", "font_path"], str, "Copyright font path", ""),
+    ("label_depth_mm", ["label", "label_depth_mm"], float, "Copyright engraving depth (mm)", ""),
+]
+
+ELEMENT_FIELDS_WING_SLUG = [
+    ("body_width_mm", ["element", "body_width_mm"], float, "Body width (mm)", "v1 Body_Width."),
+    ("body_length_mm", ["element", "body_length_mm"], float, "Body length (mm)", "v1 Body_Length."),
+    ("body_height_mm", ["element", "body_height_mm"], float, "Body height (mm)", "v1 Body_Height."),
+    ("face_thickness_mm", ["element", "face_thickness_mm"], float, "Face thickness (mm)", "v1 Face_Thickness."),
+    ("face_radius_mm", ["element", "face_radius_mm"], float, "Face corner radius (mm)", "v1 Face_Radius."),
+    ("wing_radius_mm", ["element", "wing_radius_mm"], float, "Wing radius (mm)", "v1 Wing_Radius."),
+    ("platen_shift_motion_mm", ["element", "platen_shift_motion_mm"], float, "Platen shift motion (mm)", "v1 Platen_Shift_Motion."),
+    ("baselines_shift_motion_mm", ["element", "baselines_shift_motion_mm"], float, "Baseline shift motion (mm)", "v1 Baselines_Shift_Motion."),
+    ("body_slot_width_mm", ["element", "body_slot_width_mm"], float, "Typebar slot width (mm)", "v1 Body_Slot_Width."),
+    ("wing_thickness_mm", ["element", "wing_thickness_mm"], float, "Wing minimum thickness (mm)", "v1 Wing_Thickness."),
+    ("aligning_cut_mm", ["element", "aligning_cut_mm"], float, "Aligning cut position (mm)", "v1 Aligning_Cut."),
+    ("baseline_mm", ["element", "baseline_mm"], float, "Baseline (mm)", "v1 Baseline."),
+    ("platen_diameter_mm", ["element", "platen_diameter_mm"], float, "Platen diameter (mm)", "v1 Platen_Diameter."),
+    ("bottom_thickness_mm", ["element", "bottom_thickness_mm"], float, "Bottom thickness (mm)", "v1 Bottom_Thickness."),
+    ("upper_wing_angle_deg", ["element", "upper_wing_angle_deg"], float, "Upper wing angle (deg)", "v1 Upper_Wing_Angle."),
+    ("lower_wing_angle_deg", ["element", "lower_wing_angle_deg"], float, "Lower wing angle (deg)", "v1 Lower_Wing_Angle."),
+    ("loop_enabled", ["element", "loop_enabled"], bool, "Loop enabled", "v1 Loop."),
+    ("loop_thickness_mm", ["element", "loop_thickness_mm"], float, "Loop tube thickness (mm)", "v1 Loop_Thickness."),
+    ("loop_diameter_mm", ["element", "loop_diameter_mm"], float, "Loop outer diameter (mm)", "v1 Loop_Diameter."),
+    ("loop_rotation_deg", ["element", "loop_rotation_deg"], float, "Loop rotation (deg)", "v1 Loop_Rotation."),
+    ("post_enabled", ["element", "post_enabled"], bool, "Mounting post enabled", "v1 Post."),
+    ("post_id_mm", ["element", "post_id_mm"], float, "Post hole ID (mm)", "v1 Post_ID."),
+    ("post_od_mm", ["element", "post_od_mm"], float, "Post boss OD (mm)", "v1 Post_OD."),
+    ("side_hole_enabled", ["element", "side_hole_enabled"], bool, "Side hole enabled", "v1 Side_Hole."),
+    ("side_hole_id_mm", ["element", "side_hole_id_mm"], float, "Side hole diameter (mm)", "v1 Side_Hole_ID."),
+    ("side_hole_height_frac", ["element", "side_hole_height_frac"], float, "Side hole height (fraction of body height)", "v1 Side_Hole_Height."),
+]
+
+ELEMENT_FIELDS_BOX_SLUG = [
+    ("body_width_mm", ["element", "body_width_mm"], float, "Body width (mm)", "v1 Body_Width."),
+    ("body_length_mm", ["element", "body_length_mm"], float, "Body length (mm)", "v1 Body_Length."),
+    ("body_height_mm", ["element", "body_height_mm"], float, "Body height (mm)", "v1 Body_Height."),
+    ("platen_shift_motion_mm", ["element", "platen_shift_motion_mm"], float, "Platen shift motion (mm)", "v1 Platen_Shift_Motion."),
+    ("body_slot_width_mm", ["element", "body_slot_width_mm"], float, "Typebar slot width (mm)", "v1 Body_Slot_Width."),
+    ("wing_thickness_mm", ["element", "wing_thickness_mm"], float, "Wing taper thickness (mm)", "v1 Wing_Thickness."),
+    ("aligning_cut_mm", ["element", "aligning_cut_mm"], float, "Aligning cut position (mm)", "v1 Aligning_Cut."),
+    ("platen_diameter_mm", ["element", "platen_diameter_mm"], float, "Platen diameter (mm)", "v1 Platen_Diameter."),
+    ("bottom_thickness_mm", ["element", "bottom_thickness_mm"], float, "Bottom thickness (mm)", "v1 Bottom_Thickness."),
+    ("upper_wing_angle_deg", ["element", "upper_wing_angle_deg"], float, "Wing angle (deg)",
+     "v1 Upper_Wing_Angle - used for BOTH wing-angle cuts (Lower_Wing_Angle is dead in the real v1 source, see lib/box_slug.py's module docstring)."),
+    ("loop_enabled", ["element", "loop_enabled"], bool, "Loop enabled", "v1 Loop - Lumi Slug only, Oliver Slug has no Loop concept at all."),
+    ("loop_thickness_mm", ["element", "loop_thickness_mm"], float, "Loop tube thickness (mm)", "v1 Loop_Thickness."),
+    ("loop_diameter_mm", ["element", "loop_diameter_mm"], float, "Loop outer diameter (mm)", "v1 Loop_Diameter."),
+    ("loop_rotation_deg", ["element", "loop_rotation_deg"], float, "Loop rotation (deg)", "v1 Loop_Rotation."),
+]
+
+RESIN_FIELDS_WING_SLUG = [
+    ("resin_fn", ["resin", "resin_fn"], int, "Resin support facets", ""),
+    ("raft_thickness_mm", ["resin", "raft_thickness_mm"], float, "Raft thickness (mm)", "v1 Raft_Thickness."),
+    ("wire_thickness_mm", ["resin", "wire_thickness_mm"], float, "Wire thickness (mm)", "v1 Wire_Thickness."),
+    ("support_height_mm", ["resin", "support_height_mm"], float, "Support height (mm)", "v1 Support_Height."),
+    ("support_pitch_mm", ["resin", "support_pitch_mm"], float, "Support pitch (mm)", "v1 Support_Pitch."),
+]
+
+RESIN_FIELDS_BOX_SLUG = [
+    ("resin_fn", ["resin", "resin_fn"], int, "Resin support facets",
+     "Declared but not wired to any geometry - Oliver Slug/Lumi Slug have no resin-support geometry at all, see lib/box_slug.py's ResinSupport()."),
+]
+
+QUALITY_FIELDS_WING_SLUG = [
+    ("corner_fn", ["quality", "corner_fn"], int, "Body corner facets", ""),
+    ("wing_fn", ["quality", "wing_fn"], int, "Wing cylinder facets", ""),
+    ("platen_fn", ["quality", "platen_fn"], int, "Platen cutout facets", ""),
+    ("minkowski_fn", ["quality", "minkowski_fn"], int, "Draft cone facets", ""),
+    ("loop_fn", ["quality", "loop_fn"], int, "Loop sweep facets", ""),
+    ("loop_tube_fn", ["quality", "loop_tube_fn"], int, "Loop tube cross-section facets",
+     "Kept independent from Loop sweep facets - see scad_primitives.torus()'s docstring."),
+    ("post_fn", ["quality", "post_fn"], int, "Post facets", ""),
+    ("side_hole_fn", ["quality", "side_hole_fn"], int, "Side hole facets", ""),
+]
+
+QUALITY_FIELDS_BOX_SLUG = [
+    ("minkowski_fn", ["quality", "minkowski_fn"], int, "Draft cone facets", ""),
+    ("platen_fn", ["quality", "platen_fn"], int, "Platen cutout facets", ""),
+    ("loop_fn", ["quality", "loop_fn"], int, "Loop sweep facets", ""),
+    ("loop_tube_fn", ["quality", "loop_tube_fn"], int, "Loop tube cross-section facets",
+     "Kept independent from Loop sweep facets - see scad_primitives.torus()'s docstring."),
+]
+
+# Named "Ticks", NOT "Gauge" - deliberately avoids colliding with the
+# existing Blickensderfer/Postal "Gauge" concept (a Shaft Gauge Test
+# CALIBRATION PRINT, gated by has_gauge/GaugeTestSet() in
+# _compose_build_tab). Gauge Slug's ticks are real element geometry
+# (gauge_slug.py's own Ticks(), gated by gauge.gauge_enabled), not a
+# build-target option - reusing "Gauge" here would make
+# _compose_build_tab wrongly offer a "Shaft Gauge" build target that
+# calls a GaugeTestSet() gauge_slug.py doesn't implement.
+TICKS_FIELDS_GAUGE_SLUG = [
+    ("fine_pitch_mm", ["gauge", "fine_pitch_mm"], float, "Fine tick pitch (mm)", "v1 GaugeTypeSlugSlug.scad's fine-row loop step."),
+    ("major_pitch_mm", ["gauge", "major_pitch_mm"], float, "Major tick pitch (mm)", "v1 GaugeTypeSlugSlug.scad's major-row loop step."),
+    ("hole_d_mm", ["gauge", "hole_d_mm"], float, "Tick hole diameter (mm)", ""),
+    ("fine_z_mm", ["gauge", "fine_z_mm"], float, "Fine row Z position (mm)", ""),
+    ("major_z_mm", ["gauge", "major_z_mm"], float, "Major row Z position (mm)", ""),
+    ("hole_fn", ["gauge", "hole_fn"], int, "Tick hole facets", ""),
+]
+
 SECTIONS_BY_MACHINE = {
     "blickensderfer": {**SECTIONS_COMMON, "Logo": LOGO_FIELDS_BLICKPOSTAL,
                        "Quality": QUALITY_FIELDS_BLICKPOSTAL, "Resin": RESIN_FIELDS_BLICKPOSTAL,
@@ -1115,6 +1274,35 @@ SECTIONS_BY_MACHINE = {
     "selectric_composer": {"Font & Alignment": FONT_FIELDS_SELECTRIC_COMPOSER, "Label": LABEL_FIELDS_SELECTRIC,
                            "Quality": QUALITY_FIELDS_SELECTRIC, "Resin": RESIN_FIELDS_SELECTRIC,
                            "Element": ELEMENT_FIELDS_SELECTRIC},
+    # Type Slug family (see the FIELDS block comment above this dict) -
+    # "Font & Alignment" reuses ONLY that one SECTIONS_COMMON list (not
+    # the whole dict spread, which would also pull in "Calibration" -
+    # not implemented for this family). No "Gauge"/"Calibration" key.
+    "type_slug": {"Font & Alignment": SECTIONS_COMMON["Font & Alignment"],
+                  "Character": CHARACTER_FIELDS_WING_SLUG, "Logo": LOGO_FIELDS_SLUG,
+                  "Label": LABEL_FIELDS_SLUG, "Quality": QUALITY_FIELDS_WING_SLUG,
+                  "Resin": RESIN_FIELDS_WING_SLUG, "Element": ELEMENT_FIELDS_WING_SLUG},
+    "vogue_slug": {"Font & Alignment": SECTIONS_COMMON["Font & Alignment"],
+                   "Character": CHARACTER_FIELDS_WING_SLUG, "Logo": LOGO_FIELDS_SLUG,
+                   "Label": LABEL_FIELDS_SLUG, "Quality": QUALITY_FIELDS_WING_SLUG,
+                   "Resin": RESIN_FIELDS_WING_SLUG, "Element": ELEMENT_FIELDS_WING_SLUG},
+    # "Ticks" (not "Gauge") - see TICKS_FIELDS_GAUGE_SLUG's own comment
+    # for why this deliberately doesn't reuse the existing "Gauge"
+    # section name.
+    "gauge_slug": {"Font & Alignment": SECTIONS_COMMON["Font & Alignment"],
+                   "Character": CHARACTER_FIELDS_WING_SLUG, "Logo": LOGO_FIELDS_SLUG,
+                   "Label": LABEL_FIELDS_SLUG, "Ticks": TICKS_FIELDS_GAUGE_SLUG,
+                   "Quality": QUALITY_FIELDS_WING_SLUG, "Resin": RESIN_FIELDS_WING_SLUG,
+                   "Element": ELEMENT_FIELDS_WING_SLUG},
+    # No "Label"/"Logo" key - OliverSlug.scad/LumiSlug.scad have no
+    # engraved-copyright/SVG-logo concept at all (see lib/box_slug.py's
+    # module docstring).
+    "oliver_slug": {"Font & Alignment": SECTIONS_COMMON["Font & Alignment"],
+                    "Character": CHARACTER_FIELDS_BOX_SLUG, "Quality": QUALITY_FIELDS_BOX_SLUG,
+                    "Resin": RESIN_FIELDS_BOX_SLUG, "Element": ELEMENT_FIELDS_BOX_SLUG},
+    "lumi_slug": {"Font & Alignment": SECTIONS_COMMON["Font & Alignment"],
+                  "Character": CHARACTER_FIELDS_BOX_SLUG, "Quality": QUALITY_FIELDS_BOX_SLUG,
+                  "Resin": RESIN_FIELDS_BOX_SLUG, "Element": ELEMENT_FIELDS_BOX_SLUG},
 }
 
 # Static intro banner shown above a section tab's fields, keyed by section
@@ -1734,6 +1922,14 @@ RESIN_SUPPORT_UNAVAILABLE_NOTE = {
     "helios": (
         " This checkbox has no effect for Helios - no resin support "
         "geometry is modeled (see ResinPrint() in lib/helios.py)."
+    ),
+    "oliver_slug": (
+        " This checkbox has no effect for Oliver Slug - no resin support "
+        "geometry is modeled (see ResinPrint() in lib/box_slug.py)."
+    ),
+    "lumi_slug": (
+        " This checkbox has no effect for Lumi Slug - no resin support "
+        "geometry is modeled (see ResinPrint() in lib/box_slug.py)."
     ),
 }
 

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -2971,10 +2971,19 @@ class TuneApp(App):
                 yield Button("Change Machine", id="btn-change-machine")
             with TabbedContent():
                 yield from self._compose_section_tab("Font & Alignment")
+                # "Character" - Type Slug family only (which character(s)
+                # get struck - see CHARACTER_FIELDS_WING_SLUG/_BOX_SLUG).
+                if "Character" in self.SECTIONS:
+                    yield from self._compose_section_tab("Character")
                 yield from self._compose_type_test_tab()
                 yield from self._compose_section_tab("Resin")
                 if "Gauge" in self.SECTIONS:
                     yield from self._compose_section_tab("Gauge")
+                # "Ticks" - Gauge Slug only (its tick-mark measuring
+                # ladder - see TICKS_FIELDS_GAUGE_SLUG's own comment for
+                # why this is a separate section from "Gauge" above).
+                if "Ticks" in self.SECTIONS:
+                    yield from self._compose_section_tab("Ticks")
                 # no "Calibration" key for the Selectric family - no
                 # CalibrationElement/CalibrationAdditive implemented yet
                 # (see SECTIONS_BY_MACHINE's Selectric comment).


### PR DESCRIPTION
## Summary
- Ports v1/Type Slugs/*.scad (never carried into v2) into 5 new v4 machines: Type Slug, Vogue Slug, Gauge Slug, Oliver Slug, Lumi Slug.
- Two shared engines: `lib/wing_slug.py` (rounded-hull body family: type_slug/vogue_slug/gauge_slug) and `lib/box_slug.py` (plain-box body family: oliver_slug/lumi_slug), following the existing "shared engine + thin variant" pattern from `spherical_machine.py`/`selectric*.py`.
- New `lib/svg_import.py` - a real SVG path parser (v4 had no SVG-import capability before this) for Vogue Slug's 2-piece foundry mark and the generic AR1.svg logo, reusing `glyph_poc`'s bezier-flattening and nesting-depth fill logic.
- Gauge Slug is the one real functional member of the family (a tick-mark measuring/calibration ladder meant to install on the real machine) - the rest are novelty/reference replicas, per the user's own framing.
- Full `generate.py` wiring (zero changes needed - dispatch is already generic) and `tune.py` TUI wiring (new "Slugs" machine-picker category, per-machine FIELDS/SECTIONS).
- See `SESSION_LOG.md` part 75 for the full audit, including 3 real bugs found and fixed during the port (a `scad_transform()` op-ordering bug, a 100x torus facet-count blow-up, and a `tune.py` FIELDS key-collision bug).

## Test plan
- [x] `generate.py` run for all 5 configs, both `--no-minkowski` and real Minkowski - all watertight/winding_consistent/is_volume=True.
- [x] Bounding-box sanity checks against each config's real body dimensions.
- [x] `tune.py` headless-tested against scratch config copies (never the real master/running files) - `SECTIONS`/`FIELDS` construction plus a real `patch_yaml_value()` round-trip over every field for all 5 machines.
- [x] Regression check on two existing configs (`bennett.yaml`, `selectric12.yaml`) after the shared-file edits (`scad_primitives.py`, `tune.py`) - both still watertight/winding_consistent/is_volume=True.

🤖 Generated with [Claude Code](https://claude.com/claude-code)