### PR TITLE
v4/mignon: right-side-up resin print orientation option

### DIFF
--- a/v4/config/mignon.yaml
+++ b/v4/config/mignon.yaml
@@ -199,6 +199,22 @@ resin:
   raft_thickness: 0.0
   support_height: 4.0
   support_thickness: 2.0
+  # [upside_down, right_side_up] - v4-only, no v2 equivalent. upside_down
+  # (default) is v1/v2's original ResinPrint() flip (translate then
+  # rotate([0,180,0]) - label end down at the build plate, see lib/
+  # mignon.py's ResinPrint() docstring). right_side_up skips the flip: the
+  # shaft/keyway end (AlignmentPin, CenterShaft bore) sits at the build
+  # plate instead - see lib/mignon.py's ResinSupportShaftEnd().
+  orientation: upside_down
+  # Half-angle (degrees) around the AlignmentPin keyway (theta=0, see
+  # AlignmentPin()) that ResinSupportShaftEnd() keeps clear of rod contact
+  # points, placing a flanking pair at +/-notch_gap_deg instead of a rod
+  # at 0 - same avoidance pattern spherical_machine.ResinRodAssemble()
+  # uses around Selectric's Drive_Notch_Theta (its Tip_Notch_Offset). The
+  # keyway itself spans about +/-6.2deg at the rod ring's radius
+  # (atan((pin_width/2)/r1), r1=8.21mm) - 8.0 adds a small margin. Only
+  # used when orientation is right_side_up.
+  notch_gap_deg: 8.0
 
 output:
   directory: "output"

--- a/v4/config/mignon.yaml
+++ b/v4/config/mignon.yaml
@@ -199,6 +199,12 @@ resin:
   raft_thickness: 0.0
   support_height: 4.0
   support_thickness: 2.0
+  # v4-only - v2 hardcodes 12 evenly-spaced rods (v2/mignon.scad:341's
+  # for(n=[0:11])) in both ResinSupport() and ResinSupportShaftEnd().
+  # Increase to add more rods (both print orientations use this same
+  # count); ResinSupport() (upside_down) also adds half this many more, on
+  # alternating sectors, at a second radius near the top boss.
+  rod_count: 12
   # [upside_down, right_side_up] - v4-only, no v2 equivalent. upside_down
   # (default) is v1/v2's original ResinPrint() flip (translate then
   # rotate([0,180,0]) - label end down at the build plate, see lib/

--- a/v4/lib/mignon.py
+++ b/v4/lib/mignon.py
@@ -230,6 +230,9 @@ def configure(config_path):
     g["Resin_Rod_Raft"] = False
     g["Resin_Support_Height"] = r["support_height"]
     g["Resin_Support_Thickness"] = r["support_thickness"]
+    # v4-only print orientation toggle - see ResinPrint()/ResinSupportShaftEnd().
+    g["Resin_Orientation"] = r.get("orientation", "upside_down")
+    g["Resin_Notch_Gap_Deg"] = r.get("notch_gap_deg", 8.0)
 
     g["OUTPUT_DIR"] = cfg["output"]["directory"]
     g["OUTPUT_STL_NAME"] = cfg["output"]["stl_name"]
@@ -544,6 +547,51 @@ def ResinSupport():
     return sp.union_all(parts)
 
 
+def ResinSupportShaftEnd():
+    """v4-only - no v2 equivalent. Resin support for the "right_side_up"
+    print orientation (see ResinPrint()/resin.orientation): the shaft/
+    mechanical end (Z=0, no flip) sits at the build plate instead of the
+    label end ResinSupport() attaches to. Same raft-ring-plus-rods shape
+    as ResinSupport(), adapted to this face's own radii (Cylinder_Bottom_
+    Shaft_Diameter/2, the HollowBody bore's rim at Z=0, instead of
+    Cylinder_Top_Shaft_Diameter/2's boss step) - no second, smaller-radius
+    rod ring, since the shaft end has no boss feature to justify one.
+
+    AlignmentPin() cuts a radial keyway through this exact face at
+    theta=0 (confirmed: its world bounds are x=[0, Cylinder_Bottom_Shaft_
+    Diameter/2+Pin_Depth], y=+/-Pin_Width/2, i.e. a slot from the center
+    out past the bore rim, centered on the +X axis) - placing a rod's
+    contact point on or near it would land the support on the alignment
+    pin's precision-fit surface. So the one rod that would normally fall
+    at theta=0 (n=11 of the evenly-spaced ring below) is skipped, and a
+    flanking pair is placed at +/-Resin_Notch_Gap_Deg instead - the same
+    avoidance pattern spherical_machine.ResinRodAssemble() uses around
+    Selectric's Drive_Notch_Theta (its Tip_Notch_Offset)."""
+    _require_configured()
+    base_z = -Resin_Support_Height + z
+    raft_profile = [
+        (Element_Diameter / 2, 0),
+        (Cylinder_Bottom_Shaft_Diameter / 2, 0),
+        (Cylinder_Bottom_Shaft_Diameter / 2, Resin_Support_Thickness),
+        (Element_Diameter / 2 + Resin_Support_Thickness, Resin_Support_Thickness),
+    ]
+    parts = [sp.translate(sp.revolve_polygon(raft_profile, sections=Resin_Fn), [0, 0, base_z])]
+    r1 = (Element_Diameter + Cylinder_Bottom_Shaft_Diameter) / 4 - 0.1
+    thetas = []
+    for n in range(12):
+        theta = 360.0 / 12 * n + 360.0 / 12
+        delta = min(theta % 360, 360 - theta % 360)
+        if delta < Resin_Notch_Gap_Deg:
+            continue
+        thetas.append(theta)
+    thetas.extend([Resin_Notch_Gap_Deg, -Resin_Notch_Gap_Deg])
+    for theta in thetas:
+        rod = cylinder_machine._resin_rod(Resin_Support_Height)
+        angle = np.radians(theta)
+        parts.append(sp.translate(rod, [r1 * np.cos(angle), r1 * np.sin(angle), base_z]))
+    return sp.union_all(parts)
+
+
 def ResinPrint(flatness_tolerance_mm=None, separation_mm=None, render_core_groove=None, align_kwargs=None,
                cone_segments=None, platen_fn=None, minkowski_enabled=None,
                draft_angle_deg=None):
@@ -553,15 +601,24 @@ def ResinPrint(flatness_tolerance_mm=None, separation_mm=None, render_core_groov
     rotate([0,180,0])) before adding supports - the decorative/label end
     ends up facing the build plate (where ResinSupport() attaches, below
     the new z=0), the shaft-bore/mechanical end faces up, away from
-    supports. A real, deliberate part of Mignon's print orientation, not
-    an oversight - ported faithfully."""
+    supports. A real, deliberate part of Mignon's print orientation,
+    ported faithfully as the "upside_down" (default) resin.orientation.
+
+    "right_side_up" is a v4-only addition (no v2 equivalent): skips the
+    flip entirely and uses ResinSupportShaftEnd() instead, so the shaft/
+    mechanical end sits at the build plate and the label end faces up."""
     full, char_parts = FullElement(flatness_tolerance_mm, separation_mm, render_core_groove, align_kwargs,
                                     cone_segments=cone_segments,
                                     platen_fn=platen_fn, minkowski_enabled=minkowski_enabled,
                                     draft_angle_deg=draft_angle_deg)
-    flipped = sp.scad_transform(full, ("translate", [0, 0, Element_Height]), ("rotate", [0, 180, 0]))
-    support = ResinSupport()
-    build_log.mesh_report(support, "ResinSupport")
-    combined = sp.union_all([flipped, support])
+    if Resin_Orientation == "right_side_up":
+        support = ResinSupportShaftEnd()
+        build_log.mesh_report(support, "ResinSupportShaftEnd")
+        combined = sp.union_all([full, support])
+    else:
+        flipped = sp.scad_transform(full, ("translate", [0, 0, Element_Height]), ("rotate", [0, 180, 0]))
+        support = ResinSupport()
+        build_log.mesh_report(support, "ResinSupport")
+        combined = sp.union_all([flipped, support])
     combined, _, _, _ = sp.check_and_repair(combined, label="ResinPrint")
     return combined, char_parts

--- a/v4/lib/mignon.py
+++ b/v4/lib/mignon.py
@@ -230,6 +230,9 @@ def configure(config_path):
     g["Resin_Rod_Raft"] = False
     g["Resin_Support_Height"] = r["support_height"]
     g["Resin_Support_Thickness"] = r["support_thickness"]
+    # v4-only - v2 hardcodes 12 evenly-spaced rods (v2/mignon.scad:341's
+    # for(n=[0:11])) in both ResinSupport() and ResinSupportShaftEnd().
+    g["Resin_Rod_Count"] = r.get("rod_count", 12)
     # v4-only print orientation toggle - see ResinPrint()/ResinSupportShaftEnd().
     g["Resin_Orientation"] = r.get("orientation", "upside_down")
     g["Resin_Notch_Gap_Deg"] = r.get("notch_gap_deg", 8.0)
@@ -517,14 +520,16 @@ def CalibrationElement(test_char=None, vary_baseline=None, vary_cutout=None, sta
 
 def ResinSupport():
     """v2/mignon.scad:386-405 - entirely bespoke: its own raft ring (a
-    direct rotate_extrude() polygon, not the shared CutGroove) plus 12
-    ResinRod() calls at one radius (every sector) and 6 more (alternating
-    sectors) at a second, smaller radius near the top boss - no speed-hole/
-    drive-pin/bottom-sloped-space support concepts at all (see the module
-    docstring). Reuses cylinder_machine._resin_rod() for the rod
-    primitive itself (the one thing that IS shared - v2/lib/resin_rod.scad's
-    header: "machines whose rod placement differs... can still reuse the
-    one universal rod shape")."""
+    direct rotate_extrude() polygon, not the shared CutGroove) plus
+    Resin_Rod_Count ResinRod() calls at one radius (every sector) and half
+    that many more (alternating sectors) at a second, smaller radius near
+    the top boss - no speed-hole/drive-pin/bottom-sloped-space support
+    concepts at all (see the module docstring). Reuses cylinder_machine.
+    _resin_rod() for the rod primitive itself (the one thing that IS
+    shared - v2/lib/resin_rod.scad's header: "machines whose rod placement
+    differs... can still reuse the one universal rod shape"). v2's real
+    value is a hardcoded 12 (v2/mignon.scad:341's for(n=[0:11])) - kept as
+    the default, exposed as resin.rod_count (v4-only)."""
     _require_configured()
     base_z = -Resin_Support_Height + z
     raft_profile = [
@@ -536,12 +541,13 @@ def ResinSupport():
     parts = [sp.translate(sp.revolve_polygon(raft_profile, sections=Resin_Fn), [0, 0, base_z])]
     r1 = (Element_Diameter + Cylinder_Bottom_Shaft_Diameter) / 4 - 0.1
     r2 = (Cylinder_Top_Shaft_Diameter + Cylinder_Top_Diameter) / 4
-    for n in range(12):
-        theta = np.radians(360.0 / 12 * n + 360.0 / 12)
+    n_rods = Resin_Rod_Count
+    for n in range(n_rods):
+        theta = np.radians(360.0 / n_rods * n + 360.0 / n_rods)
         rod1 = cylinder_machine._resin_rod(Resin_Support_Height + Cylinder_Top_Height_Offset)
         parts.append(sp.translate(rod1, [r1 * np.cos(theta), r1 * np.sin(theta), base_z]))
         if n % 2 == 0:
-            theta2 = theta + np.radians(360.0 / 24)
+            theta2 = theta + np.radians(360.0 / (2 * n_rods))
             rod2 = cylinder_machine._resin_rod(Resin_Support_Height)
             parts.append(sp.translate(rod2, [r2 * np.cos(theta2), r2 * np.sin(theta2), base_z]))
     return sp.union_all(parts)
@@ -563,10 +569,11 @@ def ResinSupportShaftEnd():
     out past the bore rim, centered on the +X axis) - placing a rod's
     contact point on or near it would land the support on the alignment
     pin's precision-fit surface. So the one rod that would normally fall
-    at theta=0 (n=11 of the evenly-spaced ring below) is skipped, and a
-    flanking pair is placed at +/-Resin_Notch_Gap_Deg instead - the same
-    avoidance pattern spherical_machine.ResinRodAssemble() uses around
-    Selectric's Drive_Notch_Theta (its Tip_Notch_Offset)."""
+    exactly at theta=0 (always the last of the evenly-spaced ring below,
+    n=Resin_Rod_Count-1) is skipped, and a flanking pair is placed at
+    +/-Resin_Notch_Gap_Deg instead - the same avoidance pattern spherical_
+    machine.ResinRodAssemble() uses around Selectric's Drive_Notch_Theta
+    (its Tip_Notch_Offset)."""
     _require_configured()
     base_z = -Resin_Support_Height + z
     raft_profile = [
@@ -577,9 +584,10 @@ def ResinSupportShaftEnd():
     ]
     parts = [sp.translate(sp.revolve_polygon(raft_profile, sections=Resin_Fn), [0, 0, base_z])]
     r1 = (Element_Diameter + Cylinder_Bottom_Shaft_Diameter) / 4 - 0.1
+    n_rods = Resin_Rod_Count
     thetas = []
-    for n in range(12):
-        theta = 360.0 / 12 * n + 360.0 / 12
+    for n in range(n_rods):
+        theta = 360.0 / n_rods * n + 360.0 / n_rods
         delta = min(theta % 360, 360 - theta % 360)
         if delta < Resin_Notch_Gap_Deg:
             continue

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -500,6 +500,10 @@ RESIN_FIELDS_MIGNON = [
     ("support_height", ["resin", "support_height"], float, "Support height (mm)",
      "Raft ring's Z offset below the element, and the outer ring of rods' base height."),
     ("support_thickness", ["resin", "support_thickness"], float, "Support thickness (mm)", "Raft ring thickness."),
+    ("rod_count", ["resin", "rod_count"], int, "Rod count",
+     "Number of evenly-spaced rods around the support ring, either print orientation (see the Build "
+     "tab's Print orientation). Upside down also adds half this many more, on alternating sectors, at "
+     "a second radius near the top boss."),
 ]
 
 ELEMENT_FIELDS_MIGNON = [

--- a/v4/tune.py
+++ b/v4/tune.py
@@ -2822,6 +2822,7 @@ class TuneApp(App):
         has_calibration = "Calibration" in self.SECTIONS
         is_hammond = self.machine == "hammond"
         is_hammond_split = self.machine == "hammond_split"
+        is_mignon = self.machine == "mignon"
         hammond_parts = ("none",) if is_hammond else ()
         hammond_split_normal_target = ("normal",) if is_hammond_split else ()
         valid_targets = (("element",) + (("calibration",) if has_calibration else ())
@@ -2925,6 +2926,22 @@ class TuneApp(App):
                         'along the outer wall instead. Independent of Build target above - whenever '
                         'it builds a body with a rib ("Shuttle with Rib"), its own resin-rod supports '
                         "are always added too, regardless of this setting.",
+                        classes="field-help")
+
+                if is_mignon:
+                    orientation_now = str(self.cfg.get("resin", {}).get("orientation", "upside_down"))
+                    if orientation_now not in ("upside_down", "right_side_up"):
+                        orientation_now = "upside_down"
+                    with Horizontal(classes="picker-row"):
+                        yield Static("Print orientation", classes="field-label")
+                        yield Select([("Upside down", "upside_down"), ("Right side up", "right_side_up")],
+                                     value=orientation_now, id="build-orientation", allow_blank=False)
+                    yield Static(
+                        '"Upside down" (default) is the original v1/v2 orientation - the '
+                        "label end sits at the build plate, supports attach there. "
+                        '"Right side up" skips that flip: the shaft/keyway end sits at the '
+                        "build plate instead, with its own support layout that keeps clear "
+                        "of the AlignmentPin notch. Only matters while Resin supports is on.",
                         classes="field-help")
 
                 if is_hammond_split:
@@ -3144,6 +3161,11 @@ class TuneApp(App):
             # for the same reason as groove above.
             values["orientation"] = self.query_one("#build-orientation", Select).value
             values["horizontal_method"] = self.query_one("#build-horizontal-method", Select).value
+        if self.machine == "mignon":
+            # orientation - same bespoke Build-tab treatment as Hammond's
+            # above (see _compose_build_tab's is_mignon branch); Mignon has
+            # no horizontal_method equivalent.
+            values["orientation"] = self.query_one("#build-orientation", Select).value
         if self.machine == "hammond_split":
             # render_left/render_right - bespoke Build-tab widgets (see
             # _compose_build_tab's is_hammond_split branch), same treatment
@@ -3315,6 +3337,10 @@ class TuneApp(App):
             hm_now = str(self.cfg.get("resin", {}).get("horizontal_method", "resin_rod"))
             self.query_one("#build-horizontal-method", Select).value = (
                 hm_now if hm_now in ("cut_groove", "resin_rod") else "resin_rod")
+        if self.machine == "mignon":
+            orientation_now = str(self.cfg.get("resin", {}).get("orientation", "upside_down"))
+            self.query_one("#build-orientation", Select).value = (
+                orientation_now if orientation_now in ("upside_down", "right_side_up") else "upside_down")
         if self.machine == "hammond_split":
             b = self.cfg.get("build", {})
             self.query_one("#build-render-left", Switch).value = bool(b.get("render_left", True))


### PR DESCRIPTION
## Summary
- Adds `resin.orientation` config key to Mignon (`upside_down` default = the original v1/v2 flipped `ResinPrint()`; `right_side_up` is v4-only and skips the flip, so the shaft/keyway end sits at the build plate instead of the label end).
- New `ResinSupportShaftEnd()` builds the raft+rod support layout for that face, keeping resin-rod contact points clear of the `AlignmentPin` keyway notch (a flanking pair at `±resin.notch_gap_deg` instead of a rod landing on it - mirrors `spherical_machine.ResinRodAssemble()`'s `Tip_Notch_Offset` handling of Selectric's drive notch).
- Exposed as a "Print orientation" dropdown on `tune.py`'s Build tab, same pattern as Hammond's existing orientation `Select`.
- Default behavior (`upside_down`) is byte-identical to before this change - verified via the `--no-minkowski` hard-gate on `config/mignon.yaml` (unchanged verts/faces/volume).

## Test plan
- [x] `generate.py config/mignon.yaml --no-minkowski` (default `upside_down`) - watertight, matches pre-change geometry (same code path, unchanged).
- [x] `generate.py` against a scratch copy with `orientation: right_side_up` - watertight, valid volume.
- [x] Confirmed zero mesh intersection between `ResinSupportShaftEnd()` and `AlignmentPin()` (no support material overlapping the keyway).
- [x] `generate.py` regression check on `blickensderfer`/`postal`/`bennett`/`mignon_latvian`/`mignon_plakatschrift` - all unaffected, still watertight.
- [x] Headless `tune.py` smoke test against a scratch config (per CLAUDE.md - never against the real master/running config): dropdown mounts with correct default, selection round-trips through Save and Reload correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)